### PR TITLE
resctl-demo: Better missed requirements handling

### DIFF
--- a/resctl-demo/src/agent.rs
+++ b/resctl-demo/src/agent.rs
@@ -220,11 +220,16 @@ impl AgentMinder {
             if !self.seen_running {
                 self.seen_running = true;
                 AGENT_ZV_REQ.store(false, Ordering::Relaxed);
-                let _ = cb_sink.send(Box::new(|siv| doc::show_doc(siv, "intro", true)));
+                if AGENT_FILES.sysreqs().missed.len() == 0 {
+                    let _ = cb_sink.send(Box::new(move |siv| doc::show_doc(siv, "intro", true)));
+                };
             }
         } else if self.seen_running {
             self.seen_running = false;
             AGENT_ZV_REQ.store(true, Ordering::Relaxed);
+            let _ = cb_sink.send(Box::new(move |siv| {
+                doc::show_doc(siv, "intro.sysreqs", true)
+            }));
         }
         cb_sink
             .send(Box::new(|siv| update_agent_zoomed_view(siv)))
@@ -348,8 +353,9 @@ uncompressed tarball in the prompt below and starting rd-agent again.";
 const HELP_START: &str = "\
 rd-agent verifies requirements on start-up and refuses to start if not all \
 requirements are met. While you can force-start, missing requirements will \
-impact how the demo behaves. Once rd-agent starts, this dialog will close \
-automatically. You can also close and summon this dialog with 'a'.";
+impact how the demo behaves. To learn more about the requirements, dissmiss \
+this dialog with 'a' and read the documentation pane on the lower right \
+side. You can reopen this dialog by pressing 'a' again.";
 
 pub fn layout_factory() -> Box<impl View> {
     let layout = get_layout();
@@ -438,7 +444,7 @@ pub fn layout_factory() -> Box<impl View> {
             .title("rd-agent launcher")
             .resized(
                 SizeConstraint::Fixed((layout.screen.x * 4 / 5).max(UNIT_WIDTH + 6)),
-                SizeConstraint::Fixed((layout.main.y - layout.status.y).min(layout.screen.y - 2)),
+                SizeConstraint::Fixed(layout.main.y.min(layout.screen.y - 2)),
             ),
     )
 }

--- a/resctl-demo/src/doc.rs
+++ b/resctl-demo/src/doc.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 use cursive::direction::Orientation;
 use cursive::utils::markup::StyledString;
-use cursive::view::{Nameable, Resizable, Scrollable, SizeConstraint, View};
+use cursive::view::{Nameable, Resizable, ScrollStrategy, Scrollable, SizeConstraint, View};
 use cursive::views::{Button, Checkbox, Dialog, DummyView, LinearLayout, SliderView, TextView};
 use cursive::Cursive;
 use enum_iterator::IntoEnumIterator;
@@ -512,9 +512,9 @@ fn render_doc(doc: &RdDoc) -> impl View {
             }
         }
     }
-    let mut view = view.scrollable().show_scrollbars(true);
-    view.scroll_to_top();
-    view
+    view.scrollable()
+        .show_scrollbars(true)
+        .scroll_strategy(ScrollStrategy::StickToTop)
 }
 
 pub fn layout_factory() -> impl View {

--- a/resctl-demo/src/doc/intro.rd
+++ b/resctl-demo/src/doc/intro.rd
@@ -6,12 +6,6 @@
 *Welcome*\n
 *=======*
 
-  ***(WARNING)*** *Failed to meet %MissedSysReqs% system requirements. rd-agent
-  is force started but some demos won't behave as expected. Please visit the
-  system requirements page for more details.*
-
-%% jump intro.sysreqs            : %MissedSysReqs%  [ System Requirements ]
-
 %NeedBench%First of all, some components used by resctl-demo requires benchmarks
 for configuration. As they can take more than 10 minutes, let's start them right
 away. Please keep the system idle while the benchmarks are in progress.

--- a/resctl-demo/src/doc/intro.sysreqs.rd
+++ b/resctl-demo/src/doc/intro.sysreqs.rd
@@ -119,5 +119,4 @@ there, what automatic configurations resctl-demo may apply and how to resolve if
 
   Install the needed packages.
 
-%% jump intro                    : [ Go back to intro ]
-%% jump index                    : [ Exit to index ]
+%% jump intro                    : [ Go to intro ]

--- a/resctl-demo/src/main.rs
+++ b/resctl-demo/src/main.rs
@@ -545,6 +545,8 @@ fn main() {
     refresh_layout_and_kick(&mut siv);
     update_agent_zoomed_view(&mut siv);
 
+    let _ = doc::show_doc(&mut siv, "intro.sysreqs", true);
+
     // Run the event loop
     siv.run();
 }


### PR DESCRIPTION
Instead of cluttering the main intro doc, auto jump to sysreqs doc when rd-agent
fails to start and point the user towards it.