### PR TITLE
rd-agent: Improve and fix a bunch of resctl configurations

### DIFF
--- a/rd-agent-intf/src/oomd.rs
+++ b/rd-agent-intf/src/oomd.rs
@@ -75,8 +75,8 @@ impl Default for OomdKnobs {
             workload: OomdSliceKnobs {
                 mem_pressure: OomdSliceMemPressureKnobs {
                     disable_seq: 0,
-                    threshold: 80,
-                    duration: 180,
+                    threshold: 70,
+                    duration: 60,
                 },
                 senpai: OomdSliceSenpaiKnobs {
                     min_bytes_frac: 0.25,
@@ -86,8 +86,8 @@ impl Default for OomdKnobs {
             system: OomdSliceKnobs {
                 mem_pressure: OomdSliceMemPressureKnobs {
                     disable_seq: 0,
-                    threshold: 80,
-                    duration: 180,
+                    threshold: 70,
+                    duration: 60,
                 },
                 senpai: OomdSliceSenpaiKnobs {
                     ..Default::default()

--- a/rd-agent-intf/src/slices.rs
+++ b/rd-agent-intf/src/slices.rs
@@ -120,7 +120,7 @@ impl SliceConfig {
             },
             Slice::Host => Self {
                 cpu_weight: 10,
-                mem_min: MemoryKnob::Bytes(128 << 20),
+                mem_min: MemoryKnob::Bytes(256 << 20),
                 ..Default::default()
             },
             Slice::User => Self {

--- a/rd-agent/src/cmd.rs
+++ b/rd-agent/src/cmd.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use systemd::UnitState as US;
 use util::*;
 
-use rd_agent_intf::{RunnerState, SysReq};
+use rd_agent_intf::{RunnerState, Slice, SysReq};
 
 use super::hashd::HashdSet;
 use super::side::{SideRunner, Sideload, Sysload};
@@ -131,8 +131,11 @@ impl RunnerData {
     fn apply_workloads(&mut self) -> Result<()> {
         let cmd = &self.sobjs.cmd_file.data;
         let bench = &self.sobjs.bench_file.data;
+        let mem_low = self.sobjs.slice_file.data[Slice::Work]
+            .mem_low
+            .nr_bytes(false);
 
-        self.hashd_set.apply(&cmd.hashd, &bench.hashd)?;
+        self.hashd_set.apply(&cmd.hashd, &bench.hashd, mem_low)?;
         Ok(())
     }
 

--- a/rd-agent/src/oomd.rs
+++ b/rd-agent/src/oomd.rs
@@ -24,7 +24,7 @@ const OOMD_RULE_OVERVIEW: &str = r#"
                     {
                         "name": "dump_cgroup_overview",
                         "args": {
-                            "cgroup": "workload.slice"
+                            "cgroup": "workload.slice,system.slice"
                         }
                     }
                 ]
@@ -43,7 +43,7 @@ const OOMD_RULE_MEMORY: &str = r#"
             "name": "protection against heavy __SLICE__ thrashing",
             "detectors": [
                 [
-                    "__SLICE__ thrashes for a long time",
+                    "Sustained thrashing in __SLICE__",
                     {
                         "name": "pressure_above",
                         "args": {

--- a/rd-agent/src/slices.rs
+++ b/rd-agent/src/slices.rs
@@ -375,12 +375,14 @@ fn verify_and_fix_one_slice(
             verify_and_fix_cgrp_mem(&(path.to_string() + "/memory.high"), true, sk.mem_high)?;
         }
 
-        if !recursive_mem_prot && propagate_mem_prot(slice) {
-            verify_and_fix_mem_prot(path, "memory.min", sk.mem_min)?;
-            verify_and_fix_mem_prot(path, "memory.low", sk.mem_low)?;
-        } else {
-            verify_and_fix_mem_prot(path, "memory.min", MemoryKnob::Bytes(0))?;
-            verify_and_fix_mem_prot(path, "memory.low", MemoryKnob::Bytes(0))?;
+        if propagate_mem_prot(slice) {
+            if !recursive_mem_prot {
+                verify_and_fix_mem_prot(path, "memory.min", sk.mem_min)?;
+                verify_and_fix_mem_prot(path, "memory.low", sk.mem_low)?;
+            } else {
+                verify_and_fix_mem_prot(path, "memory.min", MemoryKnob::Bytes(0))?;
+                verify_and_fix_mem_prot(path, "memory.low", MemoryKnob::Bytes(0))?;
+            }
         }
     }
 

--- a/resctl-demo/src/agent.rs
+++ b/resctl-demo/src/agent.rs
@@ -12,7 +12,7 @@ use std::sync::Mutex;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use util::*;
 
-use rd_agent_intf::{AGENT_SVC_NAME, DFL_TOP};
+use rd_agent_intf::{Slice, AGENT_SVC_NAME, DFL_TOP};
 
 use super::doc;
 use super::journal::JournalViewId;
@@ -202,6 +202,7 @@ impl AgentMinder {
         self.started_at = SystemTime::now();
         let mut svc =
             TransientService::new_sys(AGENT_SVC_NAME.into(), args, Vec::new(), Some(0o002))?;
+        svc.set_slice(Slice::Host.name());
         svc.keep = self.keep;
         self.svc.replace(svc);
         self.svc.as_mut().unwrap().start()


### PR DESCRIPTION
* memory.low propagation was broken on !recursive_memprot machines. Fixed.
* hashd memory.low configurations now correctly split workload.slice's
  protection.
* rd-agent moved from system.slice to hostcritical.slice.
* hostcritical memory.min bumped.
* oomd thresholds adjusted, also report status on system.slice.