### PR TITLE
rd-agent: Explicitly indicate default mem_ratio with None

### DIFF
--- a/rd-agent-intf/src/cmd.rs
+++ b/rd-agent-intf/src/cmd.rs
@@ -38,7 +38,7 @@ lazy_static! {
 //  hashd[].lat_target: Latency target, defaults to 0.1 meaning 100ms
 //  hashd[].rps_target_ratio: RPS target as a ratio of bench::hashd.rps_max,
 //                            if >> 1.0, no practical rps limit, default 0.5
-//  hashd[].mem_ratio: Memory footprint adj [0.0, 1.0], set from bench
+//  hashd[].mem_ratio: Memory footprint adj [0.0, 1.0], null to use bench result
 //  hashd[].file_ratio: Pagecache portion of memory [0.0, 1.0], default ${dfl_file_ratio}
 //  hashd[].file_max_ratio: Max file_ratio, requires hashd restart [0.0, 1.0], default ${dfl_file_max_ratio}
 //  hashd[].write_ratio: IO write bandwidth adj [0.0, 1.0], default ${dfl_write_ratio}
@@ -63,7 +63,7 @@ pub struct HashdCmd {
     pub active: bool,
     pub lat_target: f64,
     pub rps_target_ratio: f64,
-    pub mem_ratio: f64,
+    pub mem_ratio: Option<f64>,
     pub file_ratio: f64,
     pub file_max_ratio: f64,
     pub write_ratio: f64,
@@ -80,7 +80,7 @@ impl Default for HashdCmd {
             active: false,
             lat_target: 100.0 * MSEC,
             rps_target_ratio: 0.5,
-            mem_ratio: 0.1,
+            mem_ratio: None,
             file_ratio: rd_hashd_intf::Params::DFL_FILE_FRAC,
             file_max_ratio: rd_hashd_intf::Args::DFL_FILE_MAX_FRAC,
             write_ratio: Self::DFL_WRITE_RATIO,

--- a/rd-agent/src/cmd.rs
+++ b/rd-agent/src/cmd.rs
@@ -239,7 +239,7 @@ impl RunnerData {
                     US::Running => Ok(()),
                     US::Exited => {
                         info!("cmd: benchmark finished, loading the results");
-                        let cmd = &self.sobjs.cmd_file.data;
+                        let cmd = &mut self.sobjs.cmd_file.data;
                         let bf = &mut self.sobjs.bench_file;
                         if self.state == BenchHashd {
                             bench::update_hashd(&mut bf.data, &self.cfg, cmd.bench_hashd_seq)?;

--- a/rd-agent/src/hashd.rs
+++ b/rd-agent/src/hashd.rs
@@ -71,7 +71,11 @@ impl Hashd {
         let bench_size = (knobs.actual_mem_size() as f64).max(1.0);
         let sys_size = *TOTAL_MEMORY as f64 - mem_low as f64;
         let max_size = bench_size - sys_size;
-        let target_size = max_size * cmd.mem_ratio;
+        let mem_ratio = match cmd.mem_ratio {
+            Some(v) => v,
+            None => knobs.mem_frac,
+        };
+        let target_size = max_size * mem_ratio;
         let mem_frac = (target_size / bench_size).max(0.0).min(1.0);
 
         let mut params = rd_hashd_intf::Params::load(&self.params_path)?;
@@ -112,7 +116,7 @@ impl Hashd {
                     .unwrap(),
                 cmd.lat_target * TO_MSEC,
                 rps_target,
-                cmd.mem_ratio * TO_PCT,
+                mem_ratio * TO_PCT,
                 to_kb(log_padding),
                 frac
             );


### PR DESCRIPTION
After hashd bench completes, there's no way for rd-agent to update cmd.json's
mem_ratio as it's not writeable from agent side, and resctl-demo can't trigger
action based on bench completion either. Indicate default config explicitly so
that cmd.json doesn't have to change depending on bench result.