### PR TITLE
rd-hashd/agent: Restructure log pad sizing

### DIFF
--- a/rd-agent-intf/src/cmd.rs
+++ b/rd-agent-intf/src/cmd.rs
@@ -71,7 +71,7 @@ pub struct HashdCmd {
 }
 
 impl HashdCmd {
-    pub const DFL_WRITE_RATIO: f64 = 0.25;
+    pub const DFL_WRITE_RATIO: f64 = 0.1;
 }
 
 impl Default for HashdCmd {

--- a/rd-agent/src/bench.rs
+++ b/rd-agent/src/bench.rs
@@ -20,7 +20,7 @@ const IOCOST_MODEL_PATH: &str = "/sys/fs/cgroup/io.cost.model";
 
 pub fn start_hashd_bench(cfg: &Config, wbps: u64, mem_high: u64) -> Result<TransientService> {
     let mut args = hashd::hashd_path_args(&cfg, HashdSel::A);
-    args.push(format!("--bench-max-wbps={}", wbps));
+    args.push(format!("--bench-log-wbps={}", wbps));
     args.push("--bench".into());
     debug!("args: {:#?}", &args);
 

--- a/rd-agent/src/cmd.rs
+++ b/rd-agent/src/cmd.rs
@@ -137,7 +137,7 @@ impl RunnerData {
             .mem_low
             .nr_bytes(false);
 
-        self.hashd_set.apply(&cmd.hashd, &bench.hashd, mem_low)?;
+        self.hashd_set.apply(&cmd.hashd, &bench.hashd, mem_low, bench.iocost.model.wbps)?;
         Ok(())
     }
 
@@ -159,7 +159,7 @@ impl RunnerData {
                     if bench.iocost_seq > 0 {
                         self.bench_hashd = Some(bench::start_hashd_bench(
                             &*self.cfg,
-                            bench.iocost.model.wbps,
+                            (bench.iocost.model.wbps as f64 * cmd.hashd[0].write_ratio) as u64,
                             0,
                         )?);
                         self.state = BenchHashd;

--- a/rd-agent/src/misc/iocost_coef_gen.py
+++ b/rd-agent/src/misc/iocost_coef_gen.py
@@ -296,8 +296,8 @@ if args.json:
             'rlat': rlat,
             'wpct': wpct,
             'wlat': wlat,
-            'min': 25,
-            'max': 150,
+            'min': 75,
+            'max': 125,
         },
     }
 
@@ -310,4 +310,4 @@ print(f'io.cost.model: {devnr} rbps={rbps} rseqiops={rseqiops} '
       f'rrandiops={rrandiops} wbps={wbps} wseqiops={wseqiops} '
       f'wrandiops={wrandiops}')
 print(f'io.cost.qos: {devnr} rpct={rpct} rlat={rlat} '
-      f'wpct={wpct} wlat={wlat} min=25 max=150')
+      f'wpct={wpct} wlat={wlat} min=75 max=125')

--- a/rd-hashd-intf/src/args.rs
+++ b/rd-hashd-intf/src/args.rs
@@ -118,8 +118,7 @@ lazy_static! {
                  --bench                 'Benchmark and record results in args and params file'
                  --bench-cpu             'Benchmark cpu'
                  --bench-mem             'Benchmark memory'
-                 --bench-io              'Benchmark IO'
-                 --bench-max-wbps=[BPS]  'Max write bps of IO device, bisected if not specified'
+                 --bench-log-wbps=[BPS]  'Log write bps'
              -a, --args=[FILE]           'Load base command line arguments from FILE'
              -v...                       'Sets the level of verbosity'",
             dfl_size=to_gb(dfl.size),
@@ -151,7 +150,7 @@ pub struct Args {
     pub interval: u32,
     pub rotational: Option<bool>,
     pub keep_caches: bool,
-    pub bench_max_wbps: u64,
+    pub bench_log_wbps: u64,
 
     #[serde(skip)]
     pub clear_testfiles: bool,
@@ -163,8 +162,6 @@ pub struct Args {
     pub bench_cpu: bool,
     #[serde(skip)]
     pub bench_mem: bool,
-    #[serde(skip)]
-    pub bench_io: bool,
     #[serde(skip)]
     pub verbosity: u32,
 }
@@ -193,12 +190,11 @@ impl Default for Args {
             rotational: None,
             clear_testfiles: false,
             keep_caches: false,
-            bench_max_wbps: 0,
+            bench_log_wbps: 0,
             prepare_testfiles: true,
             prepare_and_exit: false,
             bench_cpu: false,
             bench_mem: false,
-            bench_io: false,
             verbosity: 0,
         }
     }
@@ -309,12 +305,12 @@ impl JsonArgs for Args {
             updated_base = true;
         }
 
-        let bench_max_wbps = match matches.value_of("bench-max-wbps") {
+        let bench_log_wbps = match matches.value_of("bench-log-wbps") {
             Some(v) => v.parse::<u64>().unwrap(),
             None => 0,
         };
-        if self.bench_max_wbps != bench_max_wbps {
-            self.bench_max_wbps = bench_max_wbps;
+        if self.bench_log_wbps != bench_log_wbps {
+            self.bench_log_wbps = bench_log_wbps;
             updated_base = true;
         }
 
@@ -330,15 +326,13 @@ impl JsonArgs for Args {
         if !self.prepare_and_exit {
             self.bench_cpu = matches.is_present("bench-cpu");
             self.bench_mem = matches.is_present("bench-mem");
-            self.bench_io = matches.is_present("bench-io");
 
             if matches.is_present("bench") {
                 self.bench_cpu = true;
                 self.bench_mem = true;
-                self.bench_io = true;
             }
 
-            if self.bench_cpu || self.bench_mem || self.bench_io {
+            if self.bench_cpu || self.bench_mem {
                 self.prepare_testfiles = false;
             }
         }

--- a/rd-hashd/src/main.rs
+++ b/rd-hashd/src/main.rs
@@ -247,7 +247,7 @@ fn main() {
     //
     // Benchmark and exit if requested.
     //
-    if args.bench_cpu || args.bench_mem || args.bench_io {
+    if args.bench_cpu || args.bench_mem {
         let mut bench = bench::Bench::new(args_file, params_file, report_file);
         bench.run();
         exit(0);


### PR DESCRIPTION
Having separate bisection runs for mem and io didn't work out as there's no
way to find stable balance between the two. The main goal is issuing
non-trivial amount writes issued. Let's size fix the write bw at some fraction
of max write bps from iocost benchmark and bisect only memory size as before.

Some other tweaks too - with stricter iocost latency targets, on shittier
devices, vrate often gets stuck at minimum due to latency spikes under mixed
r/w load. Further restrict vrate range.