### PR TITLE
rd-hashd/agent: Further adjust log bps handling

### DIFF
--- a/rd-agent-intf/src/bench.rs
+++ b/rd-agent-intf/src/bench.rs
@@ -14,7 +14,6 @@ const BENCH_DOC: &str = "\
 //  hashd[].rps_max: Maximum RPS
 //  hashd[].mem_size: Memory size base
 //  hashd[].mem_frac: Memory size is mem_size * mem_frac, tune this if needed
-//  hashd[].log_padding: Log padding size which determines IO write bandwidth
 //  iocost.devnr: Storage device devnr
 //  iocost.model: Model parameters
 //  iocost.qos: QoS parameters
@@ -27,7 +26,6 @@ pub struct HashdKnobs {
     pub rps_max: u32,
     pub mem_size: u64,
     pub mem_frac: f64,
-    pub log_padding: u64,
 }
 
 impl HashdKnobs {

--- a/rd-agent-intf/src/cmd.rs
+++ b/rd-agent-intf/src/cmd.rs
@@ -71,7 +71,7 @@ pub struct HashdCmd {
 }
 
 impl HashdCmd {
-    pub const DFL_WRITE_RATIO: f64 = 0.1;
+    pub const DFL_WRITE_RATIO: f64 = 0.05;
 }
 
 impl Default for HashdCmd {

--- a/rd-agent/src/bench.rs
+++ b/rd-agent/src/bench.rs
@@ -18,9 +18,9 @@ use super::{hashd, Config, HashdSel};
 pub const IOCOST_QOS_PATH: &str = "/sys/fs/cgroup/io.cost.qos";
 const IOCOST_MODEL_PATH: &str = "/sys/fs/cgroup/io.cost.model";
 
-pub fn start_hashd_bench(cfg: &Config, wbps: u64, mem_high: u64) -> Result<TransientService> {
+pub fn start_hashd_bench(cfg: &Config, log_bps: u64, mem_high: u64) -> Result<TransientService> {
     let mut args = hashd::hashd_path_args(&cfg, HashdSel::A);
-    args.push(format!("--bench-log-wbps={}", wbps));
+    args.push(format!("--bench-log-bps={}", log_bps));
     args.push("--bench".into());
     debug!("args: {:#?}", &args);
 
@@ -72,7 +72,6 @@ pub fn update_hashd(knobs: &mut BenchKnobs, cfg: &Config, hashd_seq: u64) -> Res
     knobs.hashd.rps_max = params.rps_max as u32;
     knobs.hashd.mem_size = args.size;
     knobs.hashd.mem_frac = params.mem_frac;
-    knobs.hashd.log_padding = params.log_padding;
 
     knobs.hashd_seq = hashd_seq;
     knobs.timestamp = DateTime::from(SystemTime::now());

--- a/rd-agent/src/cmd.rs
+++ b/rd-agent/src/cmd.rs
@@ -137,7 +137,8 @@ impl RunnerData {
             .mem_low
             .nr_bytes(false);
 
-        self.hashd_set.apply(&cmd.hashd, &bench.hashd, mem_low, bench.iocost.model.wbps)?;
+        self.hashd_set
+            .apply(&cmd.hashd, &bench.hashd, mem_low, bench.iocost.model.wbps)?;
         Ok(())
     }
 
@@ -159,7 +160,8 @@ impl RunnerData {
                     if bench.iocost_seq > 0 {
                         self.bench_hashd = Some(bench::start_hashd_bench(
                             &*self.cfg,
-                            (bench.iocost.model.wbps as f64 * cmd.hashd[0].write_ratio) as u64,
+                            (bench.iocost.model.wbps as f64 * cmd.hashd[0].write_ratio).round()
+                                as u64,
                             0,
                         )?);
                         self.state = BenchHashd;

--- a/rd-agent/src/misc/iocost_coef_gen.py
+++ b/rd-agent/src/misc/iocost_coef_gen.py
@@ -296,8 +296,8 @@ if args.json:
             'rlat': rlat,
             'wpct': wpct,
             'wlat': wlat,
-            'min': 75,
-            'max': 125,
+            'min': 50,
+            'max': 150,
         },
     }
 
@@ -310,4 +310,4 @@ print(f'io.cost.model: {devnr} rbps={rbps} rseqiops={rseqiops} '
       f'rrandiops={rrandiops} wbps={wbps} wseqiops={wseqiops} '
       f'wrandiops={wrandiops}')
 print(f'io.cost.qos: {devnr} rpct={rpct} rlat={rlat} '
-      f'wpct={wpct} wlat={wlat} min=75 max=125')
+      f'wpct={wpct} wlat={wlat} min=50 max=150')

--- a/rd-hashd-intf/src/args.rs
+++ b/rd-hashd-intf/src/args.rs
@@ -118,7 +118,7 @@ lazy_static! {
                  --bench                 'Benchmark and record results in args and params file'
                  --bench-cpu             'Benchmark cpu'
                  --bench-mem             'Benchmark memory'
-                 --bench-log-wbps=[BPS]  'Log write bps'
+                 --bench-log-bps=[BPS]   'Log write bps at max rps'
              -a, --args=[FILE]           'Load base command line arguments from FILE'
              -v...                       'Sets the level of verbosity'",
             dfl_size=to_gb(dfl.size),
@@ -150,7 +150,7 @@ pub struct Args {
     pub interval: u32,
     pub rotational: Option<bool>,
     pub keep_caches: bool,
-    pub bench_log_wbps: u64,
+    pub bench_log_bps: u64,
 
     #[serde(skip)]
     pub clear_testfiles: bool,
@@ -190,7 +190,7 @@ impl Default for Args {
             rotational: None,
             clear_testfiles: false,
             keep_caches: false,
-            bench_log_wbps: 0,
+            bench_log_bps: 0,
             prepare_testfiles: true,
             prepare_and_exit: false,
             bench_cpu: false,
@@ -305,12 +305,12 @@ impl JsonArgs for Args {
             updated_base = true;
         }
 
-        let bench_log_wbps = match matches.value_of("bench-log-wbps") {
+        let bench_log_bps = match matches.value_of("bench-log-bps") {
             Some(v) => v.parse::<u64>().unwrap(),
             None => 0,
         };
-        if self.bench_log_wbps != bench_log_wbps {
-            self.bench_log_wbps = bench_log_wbps;
+        if self.bench_log_bps != bench_log_bps {
+            self.bench_log_bps = bench_log_bps;
             updated_base = true;
         }
 

--- a/rd-hashd/src/main.rs
+++ b/rd-hashd/src/main.rs
@@ -123,7 +123,7 @@ fn create_logger(args: &Args, params: &Params, quiet: bool) -> Option<Logger> {
             }
             match Logger::new(
                 log_dir,
-                params.log_padding,
+                params.log_padding(),
                 LOGFILE_UNIT_SIZE,
                 args.log_size,
                 (params.rps_max as f64 * LOGGER_HOLD_SEC) as usize,
@@ -261,7 +261,7 @@ fn main() {
     let asize = size - fsize;
     info!(
         "Starting hasher (maxcon={} lat={:.1}ms rps={} file={:.2}G anon={:.2}G)",
-        params.max_concurrency,
+        params.concurrency_max,
         params.p99_lat_target * TO_MSEC,
         params.rps_target,
         to_gb(fsize),

--- a/resctl-demo/src/doc.rs
+++ b/resctl-demo/src/doc.rs
@@ -329,7 +329,7 @@ fn format_knob_val(knob: &RdKnob, ratio: f64) -> String {
     let v = match knob {
         RdKnob::HashdAMem | RdKnob::HashdBMem => format_size(ratio * bench.hashd.mem_size as f64),
         RdKnob::HashdAWrite | RdKnob::HashdBWrite => {
-            format_size(ratio * bench.hashd.log_padding as f64 / HashdCmd::DFL_WRITE_RATIO)
+            format_size(ratio * bench.iocost.model.wbps as f64)
         }
         RdKnob::MemMargin => format_size(ratio * *TOTAL_MEMORY as f64),
         _ => format_pct(ratio) + "%",


### PR DESCRIPTION
* Update code so that the parameter is specified as write bps at max rps.

* Target lower default rate (5%) as some SSDs have trouble maintaining any
  kind of reasonable latency profile when there is more write load. We might
  have to lower the default further for the base demo case. This actually
  would be a pretty useful case to qualify SSDs against.

* Other adjustments.