### PR TITLE
Fix parsing oomd version

### DIFF
--- a/rd-agent/src/main.rs
+++ b/rd-agent/src/main.rs
@@ -231,10 +231,11 @@ impl Config {
             Err(e) => bail!("can't determine version ({:?})", &e),
         };
 
-        let (maj, min, rel) = match scan_fmt!(&ver_str, "{*/[v]/}{}.{}.{}", u32, u32, u32) {
-            Ok(v) => v,
-            Err(e) => bail!("invalid version string {:?} ({:?})", ver_str.trim(), &e),
-        };
+        let (maj, min, rel) =
+            match scan_fmt!(&ver_str, "{*/[v]/}{}.{}.{/([0-9]+).*/}", u32, u32, u32) {
+                Ok(v) => v,
+                Err(e) => bail!("invalid version string {:?} ({:?})", ver_str.trim(), &e),
+            };
 
         if maj == 0 && min < 3 {
             bail!(


### PR DESCRIPTION
Parsing was broken on output like this:

    $ oomd --version
    v0.3.2-13-g445d1b2