### PR TITLE
hashd: Restore DFL_FILE_MAX_FRAC to 0.25

### DIFF
--- a/rd-hashd-intf/src/args.rs
+++ b/rd-hashd-intf/src/args.rs
@@ -167,7 +167,7 @@ pub struct Args {
 }
 
 impl Args {
-    pub const DFL_SIZE_MULT: u64 = 3;
+    pub const DFL_SIZE_MULT: u64 = 2;
     //pub const DFL_FILE_MAX_FRAC: f64 = 0.25;
     pub const DFL_FILE_MAX_FRAC: f64 = 1.0; // XXX - only do files till kernel anon handling is fixed
 


### PR DESCRIPTION
This was pushed to 1.0 to work around kernel anon reclaim behavior
weirdness; however, this is making it fail to run on machines with smaller
ssds cuz the eventual testfiles become too big.

All page cache results aren't that interesting anyway. Let's revert it to
0.25 and wait for kernel to be fixed.