### PR TITLE
agent,demo: report io.cost reported io util

### DIFF
--- a/rd-agent-intf/src/report.rs
+++ b/rd-agent-intf/src/report.rs
@@ -149,6 +149,7 @@ pub struct UsageReport {
     pub swap_bytes: u64,
     pub io_rbps: u64,
     pub io_wbps: u64,
+    pub io_util: f64,
     pub cpu_pressures: (f64, f64),
     pub mem_pressures: (f64, f64),
     pub io_pressures: (f64, f64),
@@ -161,6 +162,7 @@ impl ops::AddAssign<&UsageReport> for UsageReport {
         self.swap_bytes += rhs.swap_bytes;
         self.io_rbps += rhs.io_rbps;
         self.io_wbps += rhs.io_wbps;
+        self.io_util += rhs.io_util;
         self.cpu_pressures.0 += rhs.cpu_pressures.0;
         self.cpu_pressures.1 += rhs.cpu_pressures.1;
         self.mem_pressures.0 += rhs.mem_pressures.0;
@@ -178,6 +180,7 @@ impl<T: Into<f64>> ops::DivAssign<T> for UsageReport {
         self.swap_bytes = (self.swap_bytes as f64 / div).round() as u64;
         self.io_rbps = (self.io_rbps as f64 / div).round() as u64;
         self.io_wbps = (self.io_wbps as f64 / div).round() as u64;
+        self.io_util /= div;
         self.cpu_pressures.0 /= div;
         self.cpu_pressures.1 /= div;
         self.mem_pressures.0 /= div;
@@ -231,13 +234,11 @@ impl Default for IoLatReport {
 #[derive(Clone, Default, Serialize, Deserialize)]
 pub struct IoCostReport {
     pub vrate: f64,
-    pub usage: f64,
 }
 
 impl ops::AddAssign<&IoCostReport> for IoCostReport {
     fn add_assign(&mut self, rhs: &IoCostReport) {
         self.vrate += rhs.vrate;
-        self.usage += rhs.usage;
     }
 }
 
@@ -245,7 +246,6 @@ impl<T: Into<f64>> ops::DivAssign<T> for IoCostReport {
     fn div_assign(&mut self, rhs: T) {
         let div = rhs.into();
         self.vrate /= div;
-        self.usage /= div;
     }
 }
 


### PR DESCRIPTION
Calculate io utilization from io.cost reported per-slice usages instead of
using rbps+wbps.