### PR TITLE
agent: don't generate reports w/ empty usages after usage update failures

### DIFF
--- a/rd-agent/src/report.rs
+++ b/rd-agent/src/report.rs
@@ -422,7 +422,7 @@ impl ReportFile {
             Ok(v) => v,
             Err(e) => {
                 warn!("report: Failed to update {}s usages ({:?})", self.intv, &e);
-                Default::default()
+                return;
             }
         };
 


### PR DESCRIPTION
…ures

Sometimes usage update fails because procfs calls in read_system_usage()
fails as follows.

 [ WARN] report: Failed to update 1s usages (Internal error: bug at /home/htejun/.cargo/registry/src/github.com-1ecc6299db9ec823/procfs-0.7.9/src/lib.rs:901 (please report this procfs bug)

When this happens, the current code still generates a report file but with
empty usages hashmap which makes resctl-demo trigger panic. Skip generating
report when usages can't be read.