### PR TITLE
doc: always start on the index page

### DIFF
--- a/resctl-demo/src/doc.rs
+++ b/resctl-demo/src/doc.rs
@@ -163,18 +163,6 @@ fn format_markup_tags(tag: &str) -> Option<StyledString> {
                     return empty_some;
                 }
             }
-            "WarnBench" => {
-                if bench.hashd_seq > 0 && bench.iocost_seq > 0 {
-                    return None;
-                } else {
-                    return Some(StyledString::styled(
-                        "NOTE: This section requires the benchmarks to be complete. \
-                         Please wait for them to finish and refresh this page by \
-                         pressing 'r' before proceeding.",
-                        COLOR_ALERT,
-                    ));
-                }
-            }
             "HaveBench" => {
                 if bench.hashd_seq > 0 && bench.iocost_seq > 0 {
                     return empty_some;
@@ -741,7 +729,7 @@ pub fn post_layout(siv: &mut Cursive) {
     let cur_id = CUR_DOC.read().unwrap().id.clone();
     if cur_id.len() == 0 {
         exec_one_cmd(siv, &RdCmd::Reset(RdReset::AllWithParams));
-        show_doc(siv, "intro", true, false);
+        show_doc(siv, "index", true, false);
     } else {
         show_doc(siv, &cur_id, false, false);
     }

--- a/resctl-demo/src/doc/index.rd
+++ b/resctl-demo/src/doc/index.rd
@@ -4,10 +4,18 @@
 *Table of contents*\n
 *=================*
 
+Use up and down arrows to navigate, enter to select the page.
+
+%NeedBench%***WARNING***: Bechmark results not available. Visit the
+___Welcome___ page and run the benchmarks.
+
+***WARNING***: Failed to meet %MissedSysReqs% system requirements. Visit the
+___System Requirements___ page for details.
+
 *Introduction*
 
-%% jump intro.sysreqs            : * System Requirements
 %% jump intro.pre-bench          : * Welcome
+%% jump intro.sysreqs            :   * System Requirements
 %% jump intro.iocost             :   * Iocost Parameters and Benchmark
 %% jump intro.hashd              :   * rd-hashd Workload Simulator
 %% jump intro.post-bench         : * Introduction to resctl-demo

--- a/resctl-demo/src/doc/index.rs
+++ b/resctl-demo/src/doc/index.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
-pub const SOURCES: [&str; 23] = [
+pub const SOURCES: [&str; 22] = [
     include_str!("index.rd"),
-    include_str!("intro.rd"),
     include_str!("intro.pre-bench.rd"),
     include_str!("intro.iocost.rd"),
     include_str!("intro.hashd.rd"),

--- a/resctl-demo/src/doc/intro.hashd.rd
+++ b/resctl-demo/src/doc/intro.hashd.rd
@@ -157,7 +157,9 @@ modified through the demo interface:
 
 ___*Tuning the parameters*___
 
-%WarnBench%
+%NeedBench%***WARNING***: This section requires the benchmarks to be
+complete. Please wait for them to finish and refresh this page by pressing
+'r' before proceeding.
 
 The only parameter which may need manually tuning is `mem_frac`.
 

--- a/resctl-demo/src/doc/intro.post-bench.rd
+++ b/resctl-demo/src/doc/intro.post-bench.rd
@@ -6,8 +6,6 @@
 *Introduction*\n
 *============*
 
-%WarnBench%
-
 The idea behind resource control is to distribute resources between
 workloads so that machines can be shared among different tasks without them
 interfering with each other.

--- a/resctl-demo/src/doc/intro.rd
+++ b/resctl-demo/src/doc/intro.rd
@@ -1,4 +1,0 @@
-## Copyright (c) Facebook, Inc. and its affiliates.
-%% id intro: intro redirect page
-
-%% jump intro.pre-bench

--- a/resctl-demo/src/doc/intro.sysreqs.rd
+++ b/resctl-demo/src/doc/intro.sysreqs.rd
@@ -127,4 +127,4 @@ it's currently unmet:
 
   Install the needed packages.
 
-%% jump intro                    : [ Next: Welcome ]
+%% jump intro.iocost             : [ Next: Iocost Parameters and Benchmark ]

--- a/resctl-demo/src/main.rs
+++ b/resctl-demo/src/main.rs
@@ -39,7 +39,7 @@ use rd_agent_intf::{
 };
 
 static AGENT_ZV_REQ: AtomicBool = AtomicBool::new(true);
-static SHOWED_SYSREQS: AtomicBool = AtomicBool::new(false);
+static AGENT_SEEN_RUNNING: AtomicBool = AtomicBool::new(false);
 
 pub const UNIT_WIDTH: usize = 76;
 pub const STATUS_HEIGHT: usize = 9;
@@ -86,7 +86,7 @@ lazy_static! {
         color: Some(COLOR_ALERT.into()),
     };
     pub static ref SVC_NAMES: Vec<String> = {
-        // trigger DOCS init so that SIDELOAD/SYSLOAD_NAMES get initizlied
+        // trigger DOCS init so that SIDELOAD/SYSLOAD_NAMES get initialized
         let _ = doc::DOCS.get("index");
 
         let mut names: Vec<String> = vec![
@@ -315,11 +315,9 @@ fn update_agent_zoomed_view(siv: &mut Cursive) {
             Some(ZoomedView::Agent) => {
                 siv.pop_layer();
                 zv.pop();
-                AGENT_FILES.refresh();
-                if !SHOWED_SYSREQS.load(Ordering::Relaxed) && AGENT_FILES.sysreqs().missed.len() > 0
-                {
-                    SHOWED_SYSREQS.store(true, Ordering::Relaxed);
-                    doc::show_doc(siv, "intro.sysreqs", true, false);
+                if !AGENT_SEEN_RUNNING.load(Ordering::Relaxed) {
+                    AGENT_SEEN_RUNNING.store(true, Ordering::Relaxed);
+                    doc::show_doc(siv, "index", true, false);
                 }
             }
             _ => return,


### PR DESCRIPTION
Jumping to different targets based on bench and sysreq states gets
confusing. Always start on the index page and add warnings there about bench
and sysreq states instead.