### PR TITLE
agent: misc fixes

### DIFF
--- a/rd-agent/src/hashd.rs
+++ b/rd-agent/src/hashd.rs
@@ -73,7 +73,16 @@ impl Hashd {
             None => rd_hashd_intf::Params::DFL_ADDR_STDEV,
         };
 
-        let mut params = rd_hashd_intf::Params::load(&self.params_path)?;
+        let mut params = match rd_hashd_intf::Params::load(&self.params_path) {
+            Ok(v) => v,
+            Err(e) => {
+                info!(
+                    "hashd: Failed to load {:?} ({:?}), using default",
+                    &self.params_path, &e
+                );
+                rd_hashd_intf::Params::default()
+            }
+        };
         let mut changed = false;
 
         if params.file_size_mean != knobs.hash_size {

--- a/rd-agent/src/side.rs
+++ b/rd-agent/src/side.rs
@@ -31,7 +31,7 @@ lazy_static! {
 }
 
 const LINUX_TAR_XZ_URL: &str =
-    "https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/linux-5.5.4.tar.xz";
+    "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-5.8.11.tar.xz";
 
 const SIDE_BINS: [(&str, &[u8]); 4] = [
     ("build-linux.sh", include_bytes!("side/build-linux.sh")),


### PR DESCRIPTION
* If bench.json is available but hashd param.json isn't, rd-agent currently
  aborts after failing to read the param file. Update it to generate using
  the default values instead.

* Update linux.tar to the latest kernel. The 5.5 kernel fails to build in
  some environments.