### PR TITLE
agent: commit the missed cmd_ack.rs

### DIFF
--- a/rd-agent-intf/src/cmd_ack.rs
+++ b/rd-agent-intf/src/cmd_ack.rs
@@ -1,0 +1,32 @@
+// Copyright (c) Facebook, Inc. and its affiliates.
+use serde::{Deserialize, Serialize};
+use util::*;
+
+static CMD_ACK_DOC: &str = "\
+//
+// rd-agent command ack file
+//
+// When the commands in cmd.rs are accepted for processing, its cmd_seq is
+// copied to this file. This can be used to synchronize command issuing.
+//
+";
+
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CmdAck {
+    pub cmd_seq: u64,
+}
+
+impl Default for CmdAck {
+    fn default() -> Self {
+        Self { cmd_seq: 0 }
+    }
+}
+
+impl JsonLoad for CmdAck {}
+
+impl JsonSave for CmdAck {
+    fn preamble() -> Option<String> {
+        Some(CMD_ACK_DOC.into())
+    }
+}


### PR DESCRIPTION
Forgot to add cmd_ack.rs which should have been committed with
8a279df0ba3987beb0c7cc4ff68d2199a6fa285e.