### PR TITLE
hashd, agent, demo: drop some pub const default parameters

### DIFF
--- a/rd-agent-intf/src/cmd.rs
+++ b/rd-agent-intf/src/cmd.rs
@@ -7,8 +7,8 @@ use util::*;
 use rd_hashd_intf;
 
 lazy_static! {
-    static ref CMD_DOC: String = format!(
-        "\
+    static ref CMD_DOC: String = {
+        format!("\
 //
 // rd-agent command file
 //
@@ -41,20 +41,23 @@ lazy_static! {
 //  hashd[].rps_target_ratio: RPS target as a ratio of bench::hashd.rps_max,
 //                            if >> 1.0, no practical rps limit, default 0.5
 //  hashd[].mem_ratio: Memory footprint adj [0.0, 1.0], null to use bench result
-//  hashd[].addr_stdev: Memory access stdev in ratio of mean, null to use ${dfl_addr_stdev}
 //  hashd[].file_ratio: Pagecache portion of memory [0.0, 1.0], default ${dfl_file_ratio}
 //  hashd[].file_max_ratio: Max file_ratio, requires hashd restart [0.0, 1.0], default ${dfl_file_max_ratio}
+//  hashd[].file_addr_stdev: Memory access stdev in ratio of mean, null to use ${dfl_file_addr_stdev}
+//  hashd[].anon_addr_stdev: Memory access stdev in ratio of mean, null to use ${dfl_anon_addr_stdev}
 //  hashd[].log_bps: IO write bandwidth, default ${dfl_log_bps}Mbps
 //  hashd[].weight: Relative weight between the two hashd instances
 //  sysloads{{}}: \"NAME\": \"DEF_ID\" pairs for active sysloads
 //  sideloads{{}}: \"NAME\": \"DEF_ID\" pairs for active sideloads
 //
 ",
-        dfl_addr_stdev = rd_hashd_intf::Params::DFL_ADDR_STDEV,
-        dfl_file_ratio = rd_hashd_intf::Params::DFL_FILE_FRAC,
-        dfl_file_max_ratio = rd_hashd_intf::Args::DFL_FILE_MAX_FRAC,
-        dfl_log_bps = to_mb(HashdCmd::DFL_LOG_BPS),
-    );
+                dfl_file_ratio = rd_hashd_intf::DFL_PARAMS.file_frac,
+                dfl_file_max_ratio = rd_hashd_intf::DFL_ARGS.file_max_frac,
+                dfl_file_addr_stdev = rd_hashd_intf::DFL_PARAMS.file_addr_stdev_ratio,
+                dfl_anon_addr_stdev = rd_hashd_intf::DFL_PARAMS.anon_addr_stdev_ratio,
+                dfl_log_bps = to_mb(HashdCmd::default().log_bps),
+        )
+    };
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -69,29 +72,27 @@ pub struct HashdCmd {
     pub lat_target: f64,
     pub rps_target_ratio: f64,
     pub mem_ratio: Option<f64>,
-    pub addr_stdev: Option<f64>,
+    pub file_addr_stdev: Option<f64>,
+    pub anon_addr_stdev: Option<f64>,
     pub file_ratio: f64,
     pub file_max_ratio: f64,
     pub log_bps: u64,
     pub weight: f64,
 }
 
-impl HashdCmd {
-    pub const DFL_LOG_BPS: u64 = 16 << 20;
-}
-
 impl Default for HashdCmd {
     fn default() -> Self {
         Self {
             active: false,
-            lat_target_pct: rd_hashd_intf::Params::DFL_LAT_TARGET_PCT,
+            lat_target_pct: rd_hashd_intf::DFL_PARAMS.lat_target_pct,
             lat_target: 100.0 * MSEC,
             rps_target_ratio: 0.5,
             mem_ratio: None,
-            addr_stdev: None,
-            file_ratio: rd_hashd_intf::Params::DFL_FILE_FRAC,
-            file_max_ratio: rd_hashd_intf::Args::DFL_FILE_MAX_FRAC,
-            log_bps: Self::DFL_LOG_BPS,
+            file_addr_stdev: None,
+            anon_addr_stdev: None,
+            file_ratio: rd_hashd_intf::DFL_PARAMS.file_frac,
+            file_max_ratio: rd_hashd_intf::DFL_ARGS.file_max_frac,
+            log_bps: 16 << 20,
             weight: 1.0,
         }
     }

--- a/rd-agent/src/hashd.rs
+++ b/rd-agent/src/hashd.rs
@@ -68,9 +68,14 @@ impl Hashd {
             Some(v) => v,
             None => knobs.mem_frac,
         };
-        let addr_stdev = match cmd.addr_stdev {
+
+        let file_addr_stdev = match cmd.file_addr_stdev {
             Some(v) => v,
-            None => rd_hashd_intf::Params::DFL_ADDR_STDEV,
+            None => rd_hashd_intf::DFL_PARAMS.file_addr_stdev_ratio,
+        };
+        let anon_addr_stdev = match cmd.anon_addr_stdev {
+            Some(v) => v,
+            None => rd_hashd_intf::DFL_PARAMS.anon_addr_stdev_ratio,
         };
 
         let mut params = match rd_hashd_intf::Params::load(&self.params_path) {
@@ -113,10 +118,12 @@ impl Hashd {
             params.mem_chunk_pages = knobs.mem_chunk_pages;
             changed = true;
         }
-        if params.file_addr_stdev_ratio != addr_stdev || params.anon_addr_stdev_ratio != addr_stdev
-        {
-            params.file_addr_stdev_ratio = addr_stdev;
-            params.anon_addr_stdev_ratio = addr_stdev;
+        if params.file_addr_stdev_ratio != file_addr_stdev {
+            params.file_addr_stdev_ratio = file_addr_stdev;
+            changed = true;
+        }
+        if params.anon_addr_stdev_ratio != anon_addr_stdev {
+            params.anon_addr_stdev_ratio = anon_addr_stdev;
             changed = true;
         }
         if params.file_frac != cmd.file_ratio {
@@ -207,9 +214,9 @@ impl HashdSet {
                     params_path: cfg.hashd_paths(HashdSel::A).params.clone(),
                     report_path: cfg.hashd_paths(HashdSel::A).report.clone(),
                     path_args: hashd_path_args(cfg, HashdSel::A),
-                    lat_target_pct: rd_hashd_intf::Params::DFL_LAT_TARGET_PCT,
+                    lat_target_pct: rd_hashd_intf::DFL_PARAMS.lat_target_pct,
                     rps_max: 1,
-                    file_max_ratio: rd_hashd_intf::Args::DFL_FILE_MAX_FRAC,
+                    file_max_ratio: rd_hashd_intf::DFL_ARGS.file_max_frac,
                     svc: None,
                 },
                 Hashd {
@@ -217,9 +224,9 @@ impl HashdSet {
                     params_path: cfg.hashd_paths(HashdSel::B).params.clone(),
                     report_path: cfg.hashd_paths(HashdSel::B).report.clone(),
                     path_args: hashd_path_args(cfg, HashdSel::B),
-                    lat_target_pct: rd_hashd_intf::Params::DFL_LAT_TARGET_PCT,
+                    lat_target_pct: rd_hashd_intf::DFL_PARAMS.lat_target_pct,
                     rps_max: 1,
-                    file_max_ratio: rd_hashd_intf::Args::DFL_FILE_MAX_FRAC,
+                    file_max_ratio: rd_hashd_intf::DFL_ARGS.file_max_frac,
                     svc: None,
                 },
             ],

--- a/rd-hashd-intf/src/args.rs
+++ b/rd-hashd-intf/src/args.rs
@@ -99,8 +99,8 @@ performs benchmark to determine the parameters and then starts a normal run.
 ";
 
 lazy_static! {
+    pub static ref DFL_ARGS: Args = Default::default();
     static ref ARGS_STR: String = {
-        let dfl: Args = Default::default();
         format!(
             "-t, --testfiles=[DIR]       'Testfiles directory'
              -s, --size=[SIZE]           'Max memory footprint, affects testfiles size (default: {dfl_size:.2}G)'
@@ -122,10 +122,10 @@ lazy_static! {
                  --bench-log-bps=[BPS]   'Log write bps at max rps'
              -a, --args=[FILE]           'Load base command line arguments from FILE'
              -v...                       'Sets the level of verbosity'",
-            dfl_size=to_gb(dfl.size),
-            dfl_file_max_frac=dfl.file_max_frac,
-            dfl_log_size=to_gb(dfl.log_size),
-            dfl_intv=dfl.interval)
+            dfl_size=to_gb(DFL_ARGS.size),
+            dfl_file_max_frac=DFL_ARGS.file_max_frac,
+            dfl_log_size=to_gb(DFL_ARGS.log_size),
+            dfl_intv=DFL_ARGS.interval)
     };
 }
 

--- a/rd-hashd-intf/src/lib.rs
+++ b/rd-hashd-intf/src/lib.rs
@@ -3,6 +3,6 @@ pub mod args;
 pub mod params;
 pub mod report;
 
-pub use args::Args;
-pub use params::Params;
+pub use args::{Args, DFL_ARGS};
+pub use params::{Params, DFL_PARAMS};
 pub use report::{Latencies, Report, Stat};

--- a/rd-hashd-intf/src/params.rs
+++ b/rd-hashd-intf/src/params.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 use anyhow::Result;
+use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
 use util::*;
@@ -9,6 +10,10 @@ pub struct PidParams {
     pub kp: f64,
     pub ki: f64,
     pub kd: f64,
+}
+
+lazy_static! {
+    pub static ref DFL_PARAMS: Params = Default::default();
 }
 
 const PARAMS_DOC: &str = "\
@@ -105,11 +110,6 @@ pub struct Params {
 }
 
 impl Params {
-    pub const DFL_LAT_TARGET_PCT: f64 = 0.9;
-    pub const DFL_STDEV: f64 = 0.33; // 3 sigma == mean
-    pub const DFL_ADDR_STDEV: f64 = 0.2;
-    pub const DFL_FILE_FRAC: f64 = 0.15;
-
     pub fn log_padding(&self) -> u64 {
         if self.rps_max > 0 {
             (self.log_bps as f64 / self.rps_max as f64).round() as u64
@@ -124,24 +124,24 @@ impl Default for Params {
         Self {
             control_period: 1.0,
             concurrency_max: 65536,
-            lat_target_pct: Self::DFL_LAT_TARGET_PCT,
+            lat_target_pct: 0.9,
             lat_target: 100.0 * MSEC,
             rps_target: 65536,
             rps_max: 0,
             mem_chunk_pages: 1,
             mem_frac: 0.80,
-            file_frac: Self::DFL_FILE_FRAC,
+            file_frac: 0.15,
             file_size_mean: 4 << 20,
-            file_size_stdev_ratio: Self::DFL_STDEV,
-            file_addr_stdev_ratio: Self::DFL_ADDR_STDEV,
+            file_size_stdev_ratio: 0.33,
+            file_addr_stdev_ratio: 0.2,
             file_addr_rps_base_frac: 0.5,
             anon_size_ratio: 1.0,
-            anon_size_stdev_ratio: Self::DFL_STDEV,
-            anon_addr_stdev_ratio: Self::DFL_ADDR_STDEV,
+            anon_size_stdev_ratio: 0.33,
+            anon_addr_stdev_ratio: 0.2,
             anon_addr_rps_base_frac: 0.5,
             anon_write_frac: 0.05,
             sleep_mean: 20.0 * MSEC,
-            sleep_stdev_ratio: Self::DFL_STDEV,
+            sleep_stdev_ratio: 0.33,
             cpu_ratio: 1.0,
             log_bps: 0,
             acc_dist_slots: 0,

--- a/resctl-demo/src/doc.rs
+++ b/resctl-demo/src/doc.rs
@@ -261,19 +261,17 @@ fn exec_one_cmd(siv: &mut Cursive, cmd: &RdCmd) {
             RdKnob::HashdBLatTarget => cs.hashd[1].lat_target = *val,
             RdKnob::HashdAMem => cs.hashd[0].mem_ratio = Some(*val),
             RdKnob::HashdBMem => cs.hashd[1].mem_ratio = Some(*val),
-            RdKnob::HashdAAddrStdev => {
-                if *val < 1.0 {
-                    cs.hashd[0].addr_stdev = Some(*val);
-                } else {
-                    cs.hashd[0].addr_stdev = Some(100.0);
-                }
+            RdKnob::HashdAFileAddrStdev => {
+                cs.hashd[0].file_addr_stdev = Some(if *val < 1.0 { *val } else { 100.0 });
             }
-            RdKnob::HashdBAddrStdev => {
-                if *val < 1.0 {
-                    cs.hashd[1].addr_stdev = Some(*val);
-                } else {
-                    cs.hashd[1].addr_stdev = Some(100.0);
-                }
+            RdKnob::HashdAAnonAddrStdev => {
+                cs.hashd[0].anon_addr_stdev = Some(if *val < 1.0 { *val } else { 100.0 });
+            }
+            RdKnob::HashdBFileAddrStdev => {
+                cs.hashd[1].file_addr_stdev = Some(if *val < 1.0 { *val } else { 100.0 });
+            }
+            RdKnob::HashdBAnonAddrStdev => {
+                cs.hashd[1].anon_addr_stdev = Some(if *val < 1.0 { *val } else { 100.0 });
             }
             RdKnob::HashdAFile => cs.hashd[0].file_ratio = *val,
             RdKnob::HashdBFile => cs.hashd[1].file_ratio = *val,
@@ -527,11 +525,19 @@ fn hmem_ratio(knob: Option<f64>) -> f64 {
     }
 }
 
-fn hashd_cmd_addr_stdev(hashd: &HashdCmd) -> f64 {
-    if let Some(v) = hashd.addr_stdev {
+fn hashd_cmd_file_addr_stdev(hashd: &HashdCmd) -> f64 {
+    if let Some(v) = hashd.file_addr_stdev {
         v.min(1.0)
     } else {
-        rd_hashd_intf::Params::DFL_ADDR_STDEV
+        rd_hashd_intf::DFL_PARAMS.file_addr_stdev_ratio
+    }
+}
+
+fn hashd_cmd_anon_addr_stdev(hashd: &HashdCmd) -> f64 {
+    if let Some(v) = hashd.anon_addr_stdev {
+        v.min(1.0)
+    } else {
+        rd_hashd_intf::DFL_PARAMS.anon_addr_stdev_ratio
     }
 }
 
@@ -548,8 +554,10 @@ fn refresh_knobs(siv: &mut Cursive, doc: &RdDoc, cs: &CmdState) {
             RdKnob::HashdBLatTarget => cs.hashd[1].lat_target,
             RdKnob::HashdAMem => hmem_ratio(cs.hashd[0].mem_ratio),
             RdKnob::HashdBMem => hmem_ratio(cs.hashd[1].mem_ratio),
-            RdKnob::HashdAAddrStdev => hashd_cmd_addr_stdev(&cs.hashd[0]),
-            RdKnob::HashdBAddrStdev => hashd_cmd_addr_stdev(&cs.hashd[1]),
+            RdKnob::HashdAFileAddrStdev => hashd_cmd_file_addr_stdev(&cs.hashd[0]),
+            RdKnob::HashdAAnonAddrStdev => hashd_cmd_anon_addr_stdev(&cs.hashd[0]),
+            RdKnob::HashdBFileAddrStdev => hashd_cmd_file_addr_stdev(&cs.hashd[1]),
+            RdKnob::HashdBAnonAddrStdev => hashd_cmd_anon_addr_stdev(&cs.hashd[1]),
             RdKnob::HashdAFile => cs.hashd[0].file_ratio,
             RdKnob::HashdBFile => cs.hashd[1].file_ratio,
             RdKnob::HashdAFileMax => cs.hashd[0].file_max_ratio,

--- a/resctl-demo/src/doc/comp.cgroup.mem.thrash.rd
+++ b/resctl-demo/src/doc/comp.cgroup.mem.thrash.rd
@@ -100,7 +100,8 @@ hashd's memory access pattern uniform so that all memory is accessed
 uniformly:
 
 %% (                             : [ Set uniform access pattern and reduce memory footprint ]
-%% knob hashd-addr-stdev 1.0
+%% knob hashd-file-addr-stdev 1.0
+%% knob hashd-anon-addr-stdev 1.0
 %% knob hashd-mem 0.01
 %% )
 

--- a/resctl-demo/src/doc/doc-format.rd
+++ b/resctl-demo/src/doc/doc-format.rd
@@ -119,7 +119,8 @@ have a value argument or prompt.
 %% knob   hashd-mem              : Main workload memory footprint            :
 %% knob   hashd-file             : Main workload pagecache proportion        :
 %% knob   hashd-file-max         : Main workload max pagecache proportion    :
-%% knob   hashd-addr-stdev       : Main workload access standard deviation   :
+%% knob   hashd-file-addr-stdev  : Main workload file access stdev           :
+%% knob   hashd-anon-addr-stdev  : Main workload anon access stdev           :
 %% knob   hashd-log-bps          : Main workload log write bandwidth         :
 %% knob   hashd-weight           : Main workload weight                      :
 %% knob   hashd-B-load           : Second workload load level                :
@@ -128,7 +129,8 @@ have a value argument or prompt.
 %% knob   hashd-B-mem            : Second workload memory footprint          :
 %% knob   hashd-B-file           : Second workload pagecache proportion      :
 %% knob   hashd-B-file-max       : Second workload max pagecache proportion  :
-%% knob   hashd-B-addr-stdev     : Second workload access standard deviation :
+%% knob   hashd-B-file-addr-stdev: Second workload file access stdev         :
+%% knob   hashd-B-anon-addr-stdev: Second workload anon access stdev         :
 %% knob   hashd-B-log-bps        : Second workload log write bandwidth       :
 %% knob   hashd-B-weight         : Second workload weight                    :
 %%

--- a/resctl-demo/src/doc/markup_rd.rs
+++ b/resctl-demo/src/doc/markup_rd.rs
@@ -47,8 +47,10 @@ pub enum RdKnob {
     HashdBLatTarget,
     HashdAMem,
     HashdBMem,
-    HashdAAddrStdev,
-    HashdBAddrStdev,
+    HashdAFileAddrStdev,
+    HashdAAnonAddrStdev,
+    HashdBFileAddrStdev,
+    HashdBAnonAddrStdev,
     HashdAFile,
     HashdBFile,
     HashdAFileMax,
@@ -306,7 +308,12 @@ impl RdCmd {
                     "hashd-lat-target-pct" | "hashd-A-lat-target-pct" => RdKnob::HashdALatTargetPct,
                     "hashd-lat-target" | "hashd-A-lat-target" => RdKnob::HashdALatTarget,
                     "hashd-mem" | "hashd-A-mem" => RdKnob::HashdAMem,
-                    "hashd-addr-stdev" | "hashd-A-addr-stdev" => RdKnob::HashdAAddrStdev,
+                    "hashd-file-addr-stdev" | "hashd-A-file-addr-stdev" => {
+                        RdKnob::HashdAFileAddrStdev
+                    }
+                    "hashd-anon-addr-stdev" | "hashd-A-anon-addr-stdev" => {
+                        RdKnob::HashdAAnonAddrStdev
+                    }
                     "hashd-file" | "hashd-A-file" => RdKnob::HashdAFile,
                     "hashd-file-max" | "hashd-A-file-max" => RdKnob::HashdAFileMax,
                     "hashd-log-bps" | "hashd-A-write" => RdKnob::HashdALogBps,
@@ -315,7 +322,8 @@ impl RdCmd {
                     "hashd-B-lat-target-pct" => RdKnob::HashdBLatTargetPct,
                     "hashd-B-lat-target" => RdKnob::HashdBLatTarget,
                     "hashd-B-mem" => RdKnob::HashdBMem,
-                    "hashd-B-addr-stdev" => RdKnob::HashdBAddrStdev,
+                    "hashd-B-file-addr-stdev" => RdKnob::HashdBFileAddrStdev,
+                    "hashd-B-anon-addr-stdev" => RdKnob::HashdBAnonAddrStdev,
                     "hashd-B-file" => RdKnob::HashdBFile,
                     "hashd-B-file-max" => RdKnob::HashdBFileMax,
                     "hashd-B-log-bps" => RdKnob::HashdBLogBps,


### PR DESCRIPTION
Several interface modules define pub const default parameters and then use
them to initialize default(). The intention was making the default values
easily accessible from other places but that can easily be achieved by
providing pub static default() instance. Let's drop the consts so that
default() struct is the source of truth.

* Drop rd_hashd_intf Args and Params pub consts and provide DFL_ARGS and
  DFL_PARAMS.

* The above removes the link between file_addr_stdev and anon_addr_stdev.
  Update agent and demo so that they distinguish the two.

* Drop rd_agent_intf::HashdCmd::DFL_LOG_BPS. Instantiate default() when
  needed.