### PR TITLE
Remove rustfmt.toml

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,0 @@
-# Get help on options with `rustfmt --help=config`
-# Please keep these in alphabetical order.
-edition = "2018"
-merge_derives = false
-use_field_init_shorthand = true


### PR DESCRIPTION
Killing this off to have 100% 1:1 parity between internal source and github checkout