### PR TITLE
Remove deprecated sort directives

### DIFF
--- a/rd-agent/src/misc/io_latencies.py
+++ b/rd-agent/src/misc/io_latencies.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 #
+# @nolint
 # fmt: off
 #
 # io_latencies.py  Monitor IO latency distribution of a block device.

--- a/rd-agent/src/misc/io_latencies.py
+++ b/rd-agent/src/misc/io_latencies.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 #
 # fmt: off
-# isort:skip_file
 #
 # io_latencies.py  Monitor IO latency distribution of a block device.
 #

--- a/rd-agent/src/misc/iocost_coef_gen.py
+++ b/rd-agent/src/misc/iocost_coef_gen.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
 # fmt: off
-# isort:skip_file
 #
 # Copyright (C) 2019 Tejun Heo <tj@kernel.org>
 # Copyright (C) 2019 Andy Newell <newella@fb.com>

--- a/rd-agent/src/misc/iocost_coef_gen.py
+++ b/rd-agent/src/misc/iocost_coef_gen.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 #
+# @nolint
 # fmt: off
 #
 # Copyright (C) 2019 Tejun Heo <tj@kernel.org>


### PR DESCRIPTION
These sort directives aren't necessary anymore -- it's disabled via an internal config file now.