### PR TITLE
agent, demo: add `bc` to dependency

### DIFF
--- a/rd-agent/src/side.rs
+++ b/rd-agent/src/side.rs
@@ -105,7 +105,7 @@ pub fn prepare_linux_tar(cfg: &Config) -> Result<()> {
 }
 
 pub fn startup_checks(sr_failed: &mut HashSet<SysReq>) {
-    for bin in &["gcc", "ld", "make", "bison", "flex", "pkg-config", "stress"] {
+    for bin in &["gcc", "ld", "make", "bison", "flex", "pkg-config", "stress", "bc"] {
         if find_bin(bin, Option::<&str>::None).is_none() {
             warn!("side: binary dependency {:?} is missing", bin);
             sr_failed.insert(SysReq::Dependencies);

--- a/resctl-demo/src/doc/intro.sysreqs.rd
+++ b/resctl-demo/src/doc/intro.sysreqs.rd
@@ -139,8 +139,8 @@ it's currently unmet:
   restarted.
 
 * %SysReq::Dependencies%: 'python3', 'findmnt', 'dd', 'fio', 'stdbuf',
-  'gcc', 'ld', 'make', 'bison', 'flex', 'pkg-config', 'stress', 'libssl' and
-  'libelf' must be available on the system.
+  'gcc', 'ld', 'make', 'bison', 'flex', 'pkg-config', 'stress', 'bc',
+  'libssl' and 'libelf' must be available on the system.
 
   Install the needed packages.
 


### PR DESCRIPTION
`bc` is needed for allmodconfig linux build but isn't automatically
installed on e.g. arch linux. Add it as an explicit dependency.