### PR TITLE
util: switch from dbus-rs to rustbus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,16 +426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dbus"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd9e78c210146a1860f897db03412fd5091fd73100778e43ee255cca252cf32"
-dependencies = [
- "libc",
- "libdbus-sys",
-]
-
-[[package]]
 name = "dirs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,15 +671,6 @@ name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
-
-[[package]]
-name = "libdbus-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc12a3bc971424edbbf7edaf6e5740483444db63aa8e23d3751ff12a30f306f0"
-dependencies = [
- "pkg-config",
-]
 
 [[package]]
 name = "libflate"
@@ -1270,7 +1251,6 @@ dependencies = [
  "anyhow",
  "chrono",
  "crossbeam",
- "dbus",
  "enum-iterator",
  "glob",
  "json",
@@ -1284,6 +1264,7 @@ dependencies = [
  "rd-agent-intf",
  "rd-hashd-intf",
  "regex",
+ "rustbus",
  "scan_fmt",
  "serde",
  "serde_json",
@@ -1470,6 +1451,15 @@ dependencies = [
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rustbus"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec57ec5a2344c5aa0b7e87cc36d65f453b29f713e87c72f22bd5ff314c004fc"
+dependencies = [
+ "nix 0.17.0",
 ]
 
 [[package]]
@@ -1763,7 +1753,6 @@ dependencies = [
  "clap",
  "crossbeam",
  "ctrlc",
- "dbus",
  "env_logger",
  "glob",
  "json",
@@ -1775,6 +1764,7 @@ dependencies = [
  "page_size",
  "proc-mounts",
  "rand 0.7.3",
+ "rustbus",
  "scan_fmt",
  "serde",
  "serde_json",

--- a/rd-agent/Cargo.toml
+++ b/rd-agent/Cargo.toml
@@ -14,7 +14,6 @@ rd-hashd-intf = { path = "../rd-hashd-intf" }
 anyhow = "1.0.26"
 chrono = { version = "0.4.10", features = ["serde"] }
 crossbeam = "0.7.3"
-dbus = "0.8.1"
 enum-iterator = "0.5.0"
 glob = "0.3.0"
 json = "0.12.1"
@@ -26,6 +25,7 @@ nix = "^0.19"
 procfs = "0.7.7"
 proc-mounts = "0.2.3"
 regex = "1.3.4"
+rustbus = "^0.9"
 scan_fmt = "0.2.4"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.47"

--- a/rd-agent/src/slices.rs
+++ b/rd-agent/src/slices.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 use anyhow::Result;
-use dbus;
 use enum_iterator::IntoEnumIterator;
 use glob::glob;
 use log::{debug, error, info, trace, warn};
@@ -140,16 +139,10 @@ fn propagate_one_slice(slice: Slice, resctl: &systemd::UnitResCtl) -> Result<()>
         unit.resctl = resctl.clone();
         match unit.apply() {
             Ok(()) => debug!("resctl: propagated resctl config to {:?}", &unit_name),
-            Err(e) => match e.downcast_ref::<dbus::Error>() {
-                Some(de) if de.name() == Some("org.freedesktop.systemd1.NoSuchUnit") => trace!(
-                    "resctl: skipped propagating to missing unit {:?}",
-                    &unit_name
-                ),
-                _ => warn!(
-                    "resctl: Failed to propagate config to {:?} ({:?})",
-                    &unit_name, &e
-                ),
-            },
+            Err(e) => warn!(
+                "resctl: Failed to propagate config to {:?} ({:?})",
+                &unit_name, &e
+            ),
         }
     }
     Ok(())

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -11,7 +11,6 @@ anyhow = "1.0.26"
 clap = "2.33.0"
 crossbeam = "0.7.3"
 ctrlc = { version = "3.1.3", features = ["termination"] }
-dbus = "0.8.1"
 env_logger = "0.7.1"
 glob = "0.3.0"
 json = "^0.12"
@@ -23,6 +22,7 @@ num_cpus = "1.11.1"
 page_size = "0.4.2"
 proc-mounts = "0.2.3"
 rand = { version = "0.7.2", features = ["small_rng"] }
+rustbus = "^0.9"
 scan_fmt = "0.2.4"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.47"


### PR DESCRIPTION
While the error and enum handlings are a bit painful, for the features that
util::systemd uses, rustbus can be a drop-in replacement for dbus-rs
allowing us to shed the dependency on libdbus.