### PR TITLE
demo: fix turning off hashd benchmark

### DIFF
--- a/resctl-demo/src/command.rs
+++ b/resctl-demo/src/command.rs
@@ -106,7 +106,7 @@ impl CmdState {
         let report = &af.report.data;
 
         cmd.cmd_seq += 1;
-        if self.bench_hashd_next > cmd.bench_hashd_seq {
+        if self.bench_hashd_next != cmd.bench_hashd_seq {
             cmd.bench_hashd_seq = self.bench_hashd_next;
             cmd.bench_hashd_balloon_size = Cmd::default().bench_hashd_balloon_size;
             cmd.bench_hashd_args = vec![];


### PR DESCRIPTION
55b9a1794e22 ("agent: add support for cmd::bench_hashd_args") incorrectly
changed cmd.bench_hashd_seq update so that the value is changed iff the next
value is higher making it impossible to stop hashd benchmarks. Fix it by
applying the change whenver the current value doesn't equal the next.