### PR TITLE
bench: storage: run both Up and Bisect phases to gauge available memory

### DIFF
--- a/resctl-bench/src/bench/storage.rs
+++ b/resctl-bench/src/bench/storage.rs
@@ -114,7 +114,7 @@ impl Job for StorageJob {
         rctx.wait_cond(
             |af, progress| {
                 let rep = &af.report.data;
-                if rep.bench_hashd.phase > rd_hashd_intf::Phase::BenchMemUp {
+                if rep.bench_hashd.phase > rd_hashd_intf::Phase::BenchMemBisect {
                     true
                 } else {
                     progress.set_status(&format!(


### PR DESCRIPTION
Up phase alone somtimes fails to achieve stable memory configuration.