### PR TITLE
bench: storage: report io rwbps during the final refine rounds

### DIFF
--- a/rd-agent-intf/src/report.rs
+++ b/rd-agent-intf/src/report.rs
@@ -37,6 +37,7 @@ const REPORT_DOC: &str = "\
 //  bench.hashd.svc.state: rd-hashd benchmark systemd service state
 //  bench.hashd.phase: rd-hashd benchmark phase
 //  bench.hashd.mem_probe_size: memory size rd-hashd benchmark is probing
+//  bench.hashd.mem_probe_at: the timestamp this memory probing started at
 //  bench.iocost.svc.name: iocost benchmark systemd service name
 //  bench.iocost.svc.state: iocost benchmark systemd service state
 //  hashd[].svc.name: rd-hashd systemd service name
@@ -91,11 +92,23 @@ pub struct OomdReport {
     pub sys_senpai: bool,
 }
 
-#[derive(Clone, Serialize, Deserialize, Default)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct BenchHashdReport {
     pub svc: SvcReport,
     pub phase: rd_hashd_intf::Phase,
     pub mem_probe_size: usize,
+    pub mem_probe_at: DateTime<Local>,
+}
+
+impl Default for BenchHashdReport {
+    fn default() -> Self {
+        Self {
+            svc: Default::default(),
+            phase: Default::default(),
+            mem_probe_size: 0,
+            mem_probe_at: DateTime::from(UNIX_EPOCH),
+        }
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize, Default)]
@@ -113,7 +126,7 @@ pub struct SideloaderReport {
     pub critical_why: String,
 }
 
-#[derive(Clone, Serialize, Deserialize, Default)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct HashdReport {
     pub svc: SvcReport,
     pub phase: rd_hashd_intf::Phase,
@@ -122,6 +135,22 @@ pub struct HashdReport {
     pub lat_pct: f64,
     pub lat: rd_hashd_intf::Latencies,
     pub mem_probe_frac: f64,
+    pub mem_probe_at: DateTime<Local>,
+}
+
+impl Default for HashdReport {
+    fn default() -> Self {
+        Self {
+            svc: Default::default(),
+            phase: Default::default(),
+            load: 0.0,
+            rps: 0.0,
+            lat_pct: 0.0,
+            lat: Default::default(),
+            mem_probe_frac: 0.0,
+            mem_probe_at: DateTime::from(UNIX_EPOCH),
+        }
+    }
 }
 
 impl ops::AddAssign<&HashdReport> for HashdReport {

--- a/rd-agent/src/hashd.rs
+++ b/rd-agent/src/hashd.rs
@@ -205,6 +205,7 @@ impl Hashd {
             lat_pct: self.lat_target_pct,
             lat: hashd_r.hasher.lat,
             mem_probe_frac: hashd_r.mem_probe_frac,
+            mem_probe_at: hashd_r.mem_probe_at,
         })
     }
 }

--- a/rd-agent/src/report.rs
+++ b/rd-agent/src/report.rs
@@ -550,16 +550,13 @@ impl ReportWorker {
 
         let hashd = runner.hashd_set.report(expiration)?;
 
-        let (bench_hashd, bench_hashd_phase, bench_hashd_mem_probe_size) =
-            match runner.bench_hashd.as_mut() {
-                Some(svc) => (
-                    super::svc_refresh_and_report(&mut svc.unit)?,
-                    hashd[0].phase,
-                    (runner.sobjs.bench_file.data.hashd.mem_size as f64 * hashd[0].mem_probe_frac)
-                        as usize,
-                ),
-                None => (Default::default(), Default::default(), Default::default()),
-            };
+        let (bench_hashd, bench_hashd_phase) = match runner.bench_hashd.as_mut() {
+            Some(svc) => (
+                super::svc_refresh_and_report(&mut svc.unit)?,
+                hashd[0].phase,
+            ),
+            None => (Default::default(), Default::default()),
+        };
         let bench_iocost = match runner.bench_iocost.as_mut() {
             Some(svc) => super::svc_refresh_and_report(&mut svc.unit)?,
             None => Default::default(),
@@ -583,7 +580,10 @@ impl ReportWorker {
             bench_hashd: BenchHashdReport {
                 svc: bench_hashd,
                 phase: bench_hashd_phase,
-                mem_probe_size: bench_hashd_mem_probe_size,
+                mem_probe_size: (hashd[0].mem_probe_frac
+                    * runner.sobjs.bench_file.data.hashd.mem_size as f64)
+                    as usize,
+                mem_probe_at: hashd[0].mem_probe_at,
             },
             bench_iocost: BenchIoCostReport { svc: bench_iocost },
             hashd,

--- a/rd-hashd-intf/src/report.rs
+++ b/rd-hashd-intf/src/report.rs
@@ -183,6 +183,7 @@ const REPORT_DOC_HEADER: &str = "\
 //  testfiles_progress: Testfiles preparation progress, 1.0 indicates completion
 //  params_modified: Modified timestamp of the loaded params file
 //  mem_probe_frac: Memory frac benchmark is currently probing
+//  mem_probe_at: The timestamp this memory probing started at
 ";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -195,6 +196,7 @@ pub struct Report {
     pub testfiles_progress: f64,
     pub params_modified: DateTime<Local>,
     pub mem_probe_frac: f64,
+    pub mem_probe_at: DateTime<Local>,
     #[serde(flatten)]
     pub hasher: Stat,
 }
@@ -210,6 +212,7 @@ impl Default for Report {
             testfiles_progress: 0.0,
             params_modified: DateTime::from(UNIX_EPOCH),
             mem_probe_frac: 0.0,
+            mem_probe_at: DateTime::from(UNIX_EPOCH),
             hasher: Default::default(),
         }
     }

--- a/rd-hashd/src/bench.rs
+++ b/rd-hashd/src/bench.rs
@@ -522,7 +522,9 @@ impl Bench {
     }
 
     fn set_mem_probe_frac(&self, frac: f64) {
-        self.report_file.lock().unwrap().data.mem_probe_frac = frac;
+        let mut rep = self.report_file.lock().unwrap();
+        rep.data.mem_probe_frac = frac;
+        rep.data.mem_probe_at = chrono::Local::now();
     }
 
     fn prep_tf(&self, size: u64, why: &str) -> TestFiles {


### PR DESCRIPTION
Which likely is close to what the device would see in stable state serving
the determined memory footprint.