### PR TITLE
fix hashd bench mem_probe_size reporting

### DIFF
--- a/rd-agent-intf/src/report.rs
+++ b/rd-agent-intf/src/report.rs
@@ -136,7 +136,7 @@ pub struct HashdReport {
     pub rps: f64,
     pub lat_pct: f64,
     pub lat: rd_hashd_intf::Latencies,
-    pub mem_probe_frac: f64,
+    pub mem_probe_size: usize,
     pub mem_probe_at: DateTime<Local>,
 }
 
@@ -149,7 +149,7 @@ impl Default for HashdReport {
             rps: 0.0,
             lat_pct: 0.0,
             lat: Default::default(),
-            mem_probe_frac: 0.0,
+            mem_probe_size: 0,
             mem_probe_at: DateTime::from(UNIX_EPOCH),
         }
     }

--- a/rd-agent/src/hashd.rs
+++ b/rd-agent/src/hashd.rs
@@ -193,7 +193,7 @@ impl Hashd {
                 } else {
                     rd_hashd_intf::Report {
                         // retain fields which don't need explicit expiration
-                        mem_probe_frac: rep.mem_probe_frac,
+                        mem_probe_size: rep.mem_probe_size,
                         mem_probe_at: rep.mem_probe_at,
                         ..Default::default()
                     }
@@ -212,7 +212,7 @@ impl Hashd {
             rps: hashd_r.hasher.rps,
             lat_pct: self.lat_target_pct,
             lat: hashd_r.hasher.lat,
-            mem_probe_frac: hashd_r.mem_probe_frac,
+            mem_probe_size: hashd_r.mem_probe_size,
             mem_probe_at: hashd_r.mem_probe_at,
         })
     }

--- a/rd-agent/src/report.rs
+++ b/rd-agent/src/report.rs
@@ -528,9 +528,7 @@ impl ReportWorker {
             bench_hashd: BenchHashdReport {
                 svc: bench_hashd,
                 phase: bench_hashd_phase,
-                mem_probe_size: (hashd[0].mem_probe_frac
-                    * runner.sobjs.bench_file.data.hashd.mem_size as f64)
-                    as usize,
+                mem_probe_size: hashd[0].mem_probe_size,
                 mem_probe_at: hashd[0].mem_probe_at,
             },
             bench_iocost: BenchIoCostReport { svc: bench_iocost },

--- a/rd-hashd-intf/src/report.rs
+++ b/rd-hashd-intf/src/report.rs
@@ -194,7 +194,7 @@ pub struct Report {
     pub rotational_swap: bool,
     pub testfiles_progress: f64,
     pub params_modified: DateTime<Local>,
-    pub mem_probe_frac: f64,
+    pub mem_probe_size: usize,
     pub mem_probe_at: DateTime<Local>,
     #[serde(flatten)]
     pub hasher: Stat,
@@ -210,7 +210,7 @@ impl Default for Report {
             rotational_swap: false,
             testfiles_progress: 0.0,
             params_modified: DateTime::from(UNIX_EPOCH),
-            mem_probe_frac: 0.0,
+            mem_probe_size: 0,
             mem_probe_at: DateTime::from(UNIX_EPOCH),
             hasher: Default::default(),
         }

--- a/rd-hashd/src/bench.rs
+++ b/rd-hashd/src/bench.rs
@@ -547,7 +547,8 @@ impl Bench {
 
     fn set_mem_probe_frac(&self, frac: f64) {
         let mut rep = self.report_file.lock().unwrap();
-        rep.data.mem_probe_frac = frac;
+        let (fsize, asize) = self.mem_sizes(frac);
+        rep.data.mem_probe_size = fsize + asize;
         rep.data.mem_probe_at = chrono::Local::now();
     }
 
@@ -791,9 +792,9 @@ impl Bench {
         last_rps.round() as u32
     }
 
-    fn mem_sizes(&self, mem_frac: f64) -> (u64, u64) {
-        let size = (self.args_file.data.size as f64 * mem_frac) as u64;
-        let fsize = ((size as f64 * self.params.file_frac) as u64).min(size);
+    fn mem_sizes(&self, mem_frac: f64) -> (usize, usize) {
+        let size = (self.args_file.data.size as f64 * mem_frac) as usize;
+        let fsize = ((size as f64 * self.params.file_frac) as usize).min(size);
         let asize = size - fsize;
         (fsize, asize)
     }

--- a/resctl-bench/src/main.rs
+++ b/resctl-bench/src/main.rs
@@ -90,7 +90,10 @@ fn prep_base_bench(
         Err(e) => {
             match e.downcast_ref::<std::io::Error>() {
                 Some(e) if e.raw_os_error() == Some(libc::ENOENT) => (),
-                _ => warn!("Failed to load {:?} ({})", &demo_bench_path, &e),
+                _ => warn!(
+                    "Failed to load {:?} ({}), remove the file",
+                    &demo_bench_path, &e
+                ),
             }
             Default::default()
         }


### PR DESCRIPTION
rd-hashd was reporting mem_probe_frac and rd-agent was incorrectly
multiplying that with bench.json::mem_size which can be zero and is wrong
even when not. Fix and simplify it by making rd-hashd report mem_probe_size
instead.