### PR TITLE
Incremental bench result saving and bcc failure retries

### DIFF
--- a/rd-agent/src/misc.rs
+++ b/rd-agent/src/misc.rs
@@ -4,6 +4,10 @@ use anyhow::Result;
 use std::process::Command;
 use util::*;
 
+// bcc randomly fails to start occassionally. Give it several tries before
+// giving up.
+pub const BCC_RETRIES: u32 = 2;
+
 const MISC_BINS: [(&str, &[u8]); 4] = [
     (
         "iocost_coef_gen.py",
@@ -23,12 +27,19 @@ pub fn prepare_misc_bins(cfg: &Config) -> Result<()> {
     }
 
     if cfg.biolatpcts_bin.is_some() {
-        run_command(
-            Command::new(cfg.biolatpcts_bin.as_ref().unwrap())
-                .arg(format!("{}:{}", cfg.scr_devnr.0, cfg.scr_devnr.1))
-                .args(&["-i", "0"]),
-            "is bcc working? https://github.com/iovisor/bcc",
-        )?;
+        let mut retries = BCC_RETRIES;
+        loop {
+            match run_command(
+                Command::new(cfg.biolatpcts_bin.as_ref().unwrap())
+                    .arg(format!("{}:{}", cfg.scr_devnr.0, cfg.scr_devnr.1))
+                    .args(&["-i", "0"]),
+                "is bcc working? https://github.com/iovisor/bcc",
+            ) {
+                Ok(()) => break,
+                Err(e) if retries == 0 => return Err(e),
+                Err(_) => retries -= 1,
+            }
+        }
     }
 
     Ok(())

--- a/rd-agent/src/report.rs
+++ b/rd-agent/src/report.rs
@@ -447,6 +447,108 @@ impl ReportFile {
     }
 }
 
+struct IoLatReader {
+    biolatpcts_bin: Option<String>,
+    devnr: (u32, u32),
+    name: String,
+    intv: String,
+    tx: Option<Sender<String>>,
+    rx: Option<Receiver<String>>,
+    child: Option<Child>,
+    jh: Option<JoinHandle<()>>,
+}
+
+impl IoLatReader {
+    fn start_iolat(
+        biolatpcts_bin: &str,
+        devnr: (u32, u32),
+        name: &str,
+        intv: &str,
+        tx: Sender<String>,
+    ) -> Result<(Child, JoinHandle<()>)> {
+        let mut child = Command::new(biolatpcts_bin)
+            .arg(format!("{}:{}", devnr.0, devnr.1))
+            .args(&["-i", intv, "--json"])
+            .arg("-p")
+            .arg(
+                IoLatReport::PCTS
+                    .iter()
+                    .map(|x| format!("{}", x))
+                    .collect::<Vec<String>>()
+                    .join(","),
+            )
+            .stdout(Stdio::piped())
+            .spawn()?;
+        let name = name.to_string();
+        let stdout = child.stdout.take().unwrap();
+        let jh = spawn(move || child_reader_thread(name, stdout, tx));
+        Ok((child, jh))
+    }
+
+    fn reset(&mut self) -> Result<()> {
+        self.disconnect();
+
+        let (tx, rx) = channel::unbounded::<String>();
+        self.rx = Some(rx);
+
+        if self.biolatpcts_bin.is_some() {
+            let (child, jh) = Self::start_iolat(
+                self.biolatpcts_bin.as_ref().unwrap(),
+                self.devnr,
+                &self.name,
+                &self.intv,
+                tx,
+            )?;
+            self.child = Some(child);
+            self.jh = Some(jh);
+        } else {
+            self.tx = Some(tx);
+        }
+        Ok(())
+    }
+
+    fn new(cfg: &Config, name: &str, intv: &str) -> Result<Self> {
+        let mut iolat = Self {
+            biolatpcts_bin: cfg.biolatpcts_bin.as_ref().map(|x| x.to_owned()),
+            devnr: cfg.scr_devnr,
+            name: name.to_owned(),
+            intv: intv.to_owned(),
+            tx: None,
+            rx: None,
+            child: None,
+            jh: None,
+        };
+        iolat.reset()?;
+        Ok(iolat)
+    }
+
+    fn kick(&self) {
+        if self.child.is_some() {
+            kill(
+                Pid::from_raw(self.child.as_ref().unwrap().id() as i32),
+                Signal::SIGUSR2,
+            )
+            .unwrap();
+        }
+    }
+
+    fn disconnect(&mut self) {
+        self.tx.take();
+        self.rx.take();
+        if self.child.is_some() {
+            let _ = self.child.as_mut().unwrap().kill();
+            let _ = self.child.as_mut().unwrap().wait();
+            self.jh.take().unwrap().join().unwrap();
+        }
+    }
+}
+
+impl Drop for IoLatReader {
+    fn drop(&mut self) {
+        self.disconnect();
+    }
+}
+
 struct ReportWorker {
     runner: Runner,
     term_rx: Receiver<()>,
@@ -569,64 +671,24 @@ impl ReportWorker {
         Ok(iolat_map)
     }
 
-    fn start_iolat(
-        cfg: &Config,
-        name: &str,
-        intv: &str,
-        tx: Sender<String>,
-    ) -> (Child, JoinHandle<()>) {
-        let mut cmd = Command::new(&cfg.biolatpcts_bin.as_ref().unwrap())
-            .arg(format!("{}:{}", cfg.scr_devnr.0, cfg.scr_devnr.1))
-            .args(&["-i", intv, "--json"])
-            .arg("-p")
-            .arg(
-                IoLatReport::PCTS
-                    .iter()
-                    .map(|x| format!("{}", x))
-                    .collect::<Vec<String>>()
-                    .join(","),
-            )
-            .stdout(Stdio::piped())
-            .spawn()
-            .unwrap();
-        let name = name.to_string();
-        let stdout = cmd.stdout.take().unwrap();
-        let jh = spawn(move || child_reader_thread(name, stdout, tx));
-        (cmd, jh)
-    }
-
     fn run_inner(mut self) {
         let mut next_at = unix_now() + 1;
 
         let runner = self.runner.data.lock().unwrap();
         let cfg = &runner.cfg;
 
-        let (iolat_tx, iolat_rx) = channel::unbounded::<String>();
-        let (mut iolat, mut iolat_jh) = (None, None);
-
-        let (iolat_cum_tx, iolat_cum_rx) = channel::unbounded::<String>();
-        let (mut iolat_cum, mut iolat_cum_jh) = (None, None);
-
-        if cfg.biolatpcts_bin.is_some() {
-            let (cmd, jh) = Self::start_iolat(cfg, "iolat", "1", iolat_tx);
-            iolat = Some(cmd);
-            iolat_jh = Some(jh);
-
-            let (cmd, jh) = Self::start_iolat(cfg, "iolat_cum", "-1", iolat_cum_tx);
-            iolat_cum = Some(cmd);
-            iolat_cum_jh = Some(jh);
-        }
+        let iolat = IoLatReader::new(cfg, "iolat", "1").unwrap();
+        let iolat_cum = IoLatReader::new(cfg, "iolat_cum", "-1").unwrap();
 
         drop(runner);
         let mut sleep_dur = Duration::from_secs(0);
 
         'outer: loop {
             select! {
-                recv(iolat_rx) -> res => {
+                recv(iolat.rx.as_ref().unwrap()) -> res => {
                     // the cumulative instance doesn't have an interval,
                     // kick it and run it at the same pace as the 1s one.
-                    kill(Pid::from_raw(iolat_cum.as_ref().unwrap().id() as i32),
-                         Signal::SIGUSR2).unwrap();
+                    iolat_cum.kick();
 
                     match res {
                         Ok(line) => {
@@ -641,7 +703,7 @@ impl ReportWorker {
                         }
                     }
                 },
-                recv(iolat_cum_rx) -> res => {
+                recv(iolat_cum.rx.as_ref().unwrap()) -> res => {
                     match res {
                         Ok(line) => {
                             match Self::parse_iolat_output(&line) {
@@ -688,21 +750,6 @@ impl ReportWorker {
 
             self.report_file.tick(&base_report, now);
             self.report_file_1min.tick(&base_report, now);
-        }
-
-        drop(iolat_rx);
-        drop(iolat_cum_rx);
-
-        if iolat.is_some() {
-            let _ = iolat.as_mut().unwrap().kill();
-            let _ = iolat.as_mut().unwrap().wait();
-            iolat_jh.unwrap().join().unwrap();
-        }
-
-        if iolat_cum.is_some() {
-            let _ = iolat_cum.as_mut().unwrap().kill();
-            let _ = iolat_cum.as_mut().unwrap().wait();
-            iolat_cum_jh.unwrap().join().unwrap();
         }
     }
 

--- a/rd-hashd-intf/src/args.rs
+++ b/rd-hashd-intf/src/args.rs
@@ -121,6 +121,7 @@ lazy_static::lazy_static! {
                  --bench-cpu-single        'Benchmark hash/chunk sizes instead of taking from params'
                  --bench-cpu               'Benchmark cpu, implied by --bench'
                  --bench-mem               'Benchmark memory, implied by --bench'
+                 --bench-test              'Use quick pseudo bench for testing'
                  --bench-fake-cpu-load     'Fake CPU load while benchmarking memory'
                  --bench-hash-size=[SIZE]  'Use the specified hash size'
                  --bench-chunk-pages=[PAGES] 'Use the specified chunk pages'
@@ -179,6 +180,8 @@ pub struct Args {
     #[serde(skip)]
     pub bench_mem: bool,
     #[serde(skip)]
+    pub bench_test: bool,
+    #[serde(skip)]
     pub bench_fake_cpu_load: bool,
     #[serde(skip)]
     pub bench_hash_size: usize,
@@ -224,6 +227,7 @@ impl Default for Args {
             bench_cpu_single: false,
             bench_cpu: false,
             bench_mem: false,
+            bench_test: false,
             bench_fake_cpu_load: false,
             bench_hash_size: 0,
             bench_chunk_pages: 0,
@@ -373,6 +377,7 @@ impl JsonArgs for Args {
             self.bench_cpu_single = matches.is_present("bench-cpu-single");
             self.bench_cpu = matches.is_present("bench-cpu");
             self.bench_mem = matches.is_present("bench-mem");
+            self.bench_test = matches.is_present("bench-test");
 
             if matches.is_present("bench") {
                 self.bench_cpu = true;

--- a/resctl-bench-intf/src/args.rs
+++ b/resctl-bench-intf/src/args.rs
@@ -17,7 +17,6 @@ lazy_static::lazy_static! {
          -r, --result=[PATH]    'Record the bench results into the specified json file'
          -R, --rep-retention=[SECS] '1s report retention in seconds (default: {dfl_rep_ret:.1}h)'
          -a, --args=[FILE]      'Load base command line arguments from FILE'
-         -i, --incremental      'Run incremental benchmarks if supported (see bench helps)'
          -c, --iocost-from-sys  'Use iocost parameters from io.cost.{{model,qos}} instead of bench.json'
              --keep-reports     'Don't delete expired report files'
              --clear-reports    'Remove existing report files'
@@ -39,8 +38,6 @@ pub struct Args {
     pub job_specs: Vec<JobSpec>,
 
     #[serde(skip)]
-    pub incremental: bool,
-    #[serde(skip)]
     pub iocost_from_sys: bool,
     #[serde(skip)]
     pub keep_reports: bool,
@@ -61,7 +58,6 @@ impl Default for Args {
             result: None,
             job_specs: Default::default(),
             rep_retention: 24 * 3600,
-            incremental: false,
             iocost_from_sys: false,
             keep_reports: false,
             clear_reports: false,
@@ -205,7 +201,6 @@ impl JsonArgs for Args {
             updated = true;
         }
 
-        self.incremental = matches.is_present("incremental");
         self.iocost_from_sys = matches.is_present("iocost-from-sys");
         self.keep_reports = matches.is_present("keep-reports");
         self.clear_reports = matches.is_present("clear-reports");

--- a/resctl-bench-intf/src/args.rs
+++ b/resctl-bench-intf/src/args.rs
@@ -19,8 +19,9 @@ lazy_static::lazy_static! {
          -a, --args=[FILE]      'Load base command line arguments from FILE'
          -i, --incremental      'Run incremental benchmarks if supported (see bench helps)'
          -c, --iocost-from-sys  'Use iocost parameters from io.cost.{{model,qos}} instead of bench.json'
-             --clear-reports    'Remove existing report files'
              --keep-reports     'Don't delete expired report files'
+             --clear-reports    'Remove existing report files'
+             --test             'Test mode for development'
          -v...                  'Sets the level of verbosity'",
         dfl_dir = Args::default().dir,
         dfl_rep_ret = Args::default().rep_retention,
@@ -46,6 +47,8 @@ pub struct Args {
     #[serde(skip)]
     pub clear_reports: bool,
     #[serde(skip)]
+    pub test: bool,
+    #[serde(skip)]
     pub verbosity: u32,
 }
 
@@ -62,6 +65,7 @@ impl Default for Args {
             iocost_from_sys: false,
             keep_reports: false,
             clear_reports: false,
+            test: false,
             verbosity: 0,
         }
     }
@@ -205,6 +209,7 @@ impl JsonArgs for Args {
         self.iocost_from_sys = matches.is_present("iocost-from-sys");
         self.keep_reports = matches.is_present("keep-reports");
         self.clear_reports = matches.is_present("clear-reports");
+        self.test = matches.is_present("test");
         self.verbosity = Self::verbosity(matches);
 
         match matches.subcommand() {

--- a/resctl-bench/src/bench/hashd_params.rs
+++ b/resctl-bench/src/bench/hashd_params.rs
@@ -70,7 +70,7 @@ impl Job for HashdParamsJob {
             },
             None,
             Some(BenchProgress::new().monitor_systemd_unit(HASHD_BENCH_SVC_NAME)),
-        );
+        )?;
 
         let result = rctx.access_agent_files(|af| af.bench.data.hashd.clone());
 

--- a/resctl-bench/src/bench/iocost_params.rs
+++ b/resctl-bench/src/bench/iocost_params.rs
@@ -48,7 +48,7 @@ impl Job for IoCostParamsJob {
             },
             None,
             Some(BenchProgress::new().monitor_systemd_unit(IOCOST_BENCH_SVC_NAME)),
-        );
+        )?;
 
         let result = rctx.access_agent_files(|af| af.bench.data.iocost.clone());
 

--- a/resctl-bench/src/bench/storage.rs
+++ b/resctl-bench/src/bench/storage.rs
@@ -162,7 +162,9 @@ impl StorageJob {
         rctx.wait_cond(
             |af, progress| {
                 let rep = &af.report.data;
-                if rep.bench_hashd.phase > rd_hashd_intf::Phase::BenchMemBisect {
+                if rep.bench_hashd.phase > rd_hashd_intf::Phase::BenchMemBisect
+                    || rep.state != rd_agent_intf::RunnerState::BenchHashd
+                {
                     true
                 } else {
                     progress.set_status(&format!(
@@ -241,8 +243,10 @@ impl StorageJob {
                 self.mem_usage = mem_usages.iter().fold(0, |max, u| max.max(*u));
                 self.mem_probe_at = rep.bench_hashd.mem_probe_at.timestamp() as u64;
 
-                mem_avail_err =
-                    (self.mem_usage as f64 - self.mem_share as f64) / self.mem_share as f64;
+                if !rctx.test {
+                    mem_avail_err =
+                        (self.mem_usage as f64 - self.mem_share as f64) / self.mem_share as f64;
+                }
 
                 // Abort early iff we go over. Memory usage may keep rising
                 // through refine stages, so we'll check for going under

--- a/resctl-bench/src/main.rs
+++ b/resctl-bench/src/main.rs
@@ -252,6 +252,7 @@ fn main() {
                 args.linux_tar.as_deref(),
                 &base_bench,
                 jctx.result.take(),
+                args.test,
                 args.verbosity,
             );
 

--- a/resctl-bench/src/main.rs
+++ b/resctl-bench/src/main.rs
@@ -143,6 +143,18 @@ fn prep_base_bench(
     Ok((bench, demo_bench_path, bench_path))
 }
 
+pub fn save_results(path: &str, job_ctxs: &Vec<JobCtx>) {
+    let serialized = serde_json::to_string_pretty(&job_ctxs).expect("Failed to serialize output");
+    let mut f = fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .expect("Failed to open output file");
+    f.write_all(serialized.as_ref())
+        .expect("Failed to write output file");
+}
+
 fn main() {
     setup_prog_state();
     bench::init_benchs();
@@ -171,31 +183,31 @@ fn main() {
         }
     }
 
+    // Stash the result part for incremental result file updates.
+    let mut inc_job_ctxs = job_ctxs.clone();
+
     // Combine new jobs to run into job_ctxs.
     let mut nr_to_run = 0;
     'next: for spec in args.job_specs.iter() {
-        match JobCtx::process_job_spec(spec) {
-            Ok(mut new) => {
-                new.run = true;
-                nr_to_run += 1;
-                for jctx in job_ctxs.iter_mut() {
-                    if jctx.spec.kind == new.spec.kind && jctx.spec.id == new.spec.id {
-                        debug!("{} has a matching entry in the result file", &new.spec);
-                        let result = match args.incremental {
-                            true => jctx.result.take(),
-                            false => None,
-                        };
-                        *jctx = JobCtx { result, ..new };
-                        continue 'next;
-                    }
-                }
-                job_ctxs.push(new);
-            }
-            Err(e) => {
-                error!("{}: {}", spec, &e);
-                panic!();
+        let mut new = JobCtx::new(spec);
+        if let Err(e) = new.parse_job_spec() {
+            error!("{}: {}", spec, &e);
+            panic!();
+        }
+        new.run = true;
+        nr_to_run += 1;
+        for (inc_job_idx, jctx) in job_ctxs.iter_mut().enumerate() {
+            if jctx.spec.kind == new.spec.kind && jctx.spec.id == new.spec.id {
+                debug!("{} has a matching entry in the result file", &new.spec);
+                new.inc_job_idx = inc_job_idx;
+                new.result = jctx.result.take();
+                *jctx = new;
+                continue 'next;
             }
         }
+        new.inc_job_idx = inc_job_ctxs.len();
+        inc_job_ctxs.push(new.clone());
+        job_ctxs.push(new);
     }
 
     debug!("job_ctxs: nr_to_run={}\n{:#?}", nr_to_run, &job_ctxs);
@@ -252,6 +264,9 @@ fn main() {
                 args.linux_tar.as_deref(),
                 &base_bench,
                 jctx.result.take(),
+                &mut inc_job_ctxs,
+                jctx.inc_job_idx,
+                args.result.as_deref(),
                 args.test,
                 args.verbosity,
             );
@@ -274,24 +289,16 @@ fn main() {
             }
         }
 
-        if jctx.run || nr_to_run == 0 {
+        // Format only the completed jobs.
+        if (jctx.run || nr_to_run == 0) && jctx.sysreqs_report.is_some() {
             println!("{}\n\n{}", "=".repeat(90), &jctx.format());
         }
     }
 
-    // Printout the results.
+    // Write the result file.
     if !job_ctxs.is_empty() {
         if let Some(path) = args.result.as_ref() {
-            let serialized =
-                serde_json::to_string_pretty(&job_ctxs).expect("Failed to serialize output");
-            let mut f = fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(path)
-                .expect("Failed to open output file");
-            f.write_all(serialized.as_ref())
-                .expect("Failed to write output file");
+            save_results(path, &job_ctxs);
         }
     }
 }

--- a/resctl-bench/src/run.rs
+++ b/resctl-bench/src/run.rs
@@ -370,6 +370,7 @@ impl<'a> RunCtx<'a> {
 
     pub fn start_agent_fallible(&mut self, extra_args: Vec<String>) -> Result<()> {
         let mut ctx = self.inner.lock().unwrap();
+        ctx.minder_state = MinderState::Ok;
 
         ctx.start_agent(extra_args)?;
 
@@ -520,7 +521,8 @@ impl<'a> RunCtx<'a> {
             },
             Some(CMD_TIMEOUT),
             None,
-        ).expect("failed to start iocost benchmark");
+        )
+        .expect("failed to start iocost benchmark");
     }
 
     pub fn stop_iocost_bench(&self) {
@@ -536,7 +538,8 @@ impl<'a> RunCtx<'a> {
             |af, _| af.report.data.state != RunnerState::BenchIoCost,
             Some(CMD_TIMEOUT),
             None,
-        ).expect("failed to stop iocost benchmark");
+        )
+        .expect("failed to stop iocost benchmark");
     }
 
     pub fn start_hashd_bench(&self, ballon_size: usize, log_bps: u64, mut extra_args: Vec<String>) {
@@ -564,7 +567,8 @@ impl<'a> RunCtx<'a> {
             },
             Some(CMD_TIMEOUT),
             None,
-        ).expect("failed to start hashd benchmark");
+        )
+        .expect("failed to start hashd benchmark");
     }
 
     pub fn stop_hashd_bench(&self) {
@@ -580,7 +584,8 @@ impl<'a> RunCtx<'a> {
             |af, _| af.report.data.state != RunnerState::BenchHashd,
             Some(CMD_TIMEOUT),
             None,
-        ).expect("failed to stop hashd benchmark");
+        )
+        .expect("failed to stop hashd benchmark");
     }
 
     pub const BENCH_FAKE_CPU_RPS_MAX: u32 = 2000;

--- a/resctl-bench/src/run.rs
+++ b/resctl-bench/src/run.rs
@@ -96,6 +96,9 @@ impl RunCtxInner {
     }
 
     fn start_agent(&mut self, extra_args: Vec<String>) -> Result<()> {
+        if prog_exiting() {
+            bail!("exiting");
+        }
         if self.agent_svc.is_some() {
             bail!("already running");
         }

--- a/resctl-bench/src/run.rs
+++ b/resctl-bench/src/run.rs
@@ -145,6 +145,7 @@ pub struct RunCtx {
     agent_init_fns: Vec<Box<dyn FnOnce(&mut RunCtx)>>,
     base_bench: rd_agent_intf::BenchKnobs,
     prev_result: Option<serde_json::Value>,
+    pub test: bool,
     pub commit_bench: bool,
 }
 
@@ -155,6 +156,7 @@ impl RunCtx {
         linux_tar: Option<&str>,
         base_bench: &rd_agent_intf::BenchKnobs,
         prev_result: Option<serde_json::Value>,
+        test: bool,
         verbosity: u32,
     ) -> Self {
         Self {
@@ -181,6 +183,7 @@ impl RunCtx {
             base_bench: base_bench.clone(),
             agent_init_fns: vec![],
             prev_result,
+            test,
             commit_bench: false,
         }
     }
@@ -531,8 +534,12 @@ impl RunCtx {
         );
     }
 
-    pub fn start_hashd_bench(&self, ballon_size: usize, log_bps: u64, extra_args: Vec<String>) {
+    pub fn start_hashd_bench(&self, ballon_size: usize, log_bps: u64, mut extra_args: Vec<String>) {
         debug!("Starting hashd benchmark ({})", &HASHD_BENCH_SVC_NAME);
+
+        if self.test {
+            extra_args.push("--bench-test".into());
+        }
 
         let mut next_seq = 0;
         self.access_agent_files(|af| {


### PR DESCRIPTION
iocost-qos bench can run for a really long time and can fail depending on the IO device behavior. Losing the results wastes a lot of time and energy. Address it by:

* Make --incremental mode default and make iocost-qos save result in the buffering area as each run completes so that a result is never lost.
* iocost-qos bench now can retry on rd-agent failures and produce output with failed runs.
* rd-agent now retries launching biolatpcts after bcc init failures.