### PR TITLE
Allow bench runs to be nested

### DIFF
--- a/rd-agent-intf/src/bench.rs
+++ b/rd-agent-intf/src/bench.rs
@@ -25,7 +25,7 @@ const BENCH_DOC: &str = "\
 //
 ";
 
-#[derive(Clone, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(default)]
 pub struct HashdKnobs {
     pub hash_size: usize,
@@ -41,14 +41,14 @@ impl HashdKnobs {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 pub struct IoCostKnobs {
     pub devnr: String,
     pub model: IoCostModelParams,
     pub qos: IoCostQoSParams,
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BenchKnobs {
     pub timestamp: DateTime<Local>,
     pub hashd_seq: u64,

--- a/resctl-bench-intf/src/args.rs
+++ b/resctl-bench-intf/src/args.rs
@@ -78,6 +78,16 @@ impl Default for Args {
 }
 
 impl Args {
+    pub const RB_BENCH_FILENAME: &'static str = "rb-bench.json";
+
+    pub fn demo_bench_path(&self) -> String {
+        self.dir.clone() + "/" + rd_agent_intf::BENCH_FILENAME
+    }
+
+    pub fn bench_path(&self) -> String {
+        self.dir.clone() + "/" + Self::RB_BENCH_FILENAME
+    }
+
     pub fn parse_job_spec(spec: &str) -> Result<JobSpec> {
         let mut groups = spec.split(':');
 

--- a/resctl-bench-intf/src/jobspec.rs
+++ b/resctl-bench-intf/src/jobspec.rs
@@ -9,9 +9,6 @@ pub struct JobSpec {
     pub kind: String,
     pub id: Option<String>,
     pub props: JobProps,
-
-    #[serde(skip)]
-    pub preprocessed: bool,
 }
 
 impl std::cmp::PartialEq for JobSpec {
@@ -29,7 +26,6 @@ impl JobSpec {
             kind,
             id,
             props,
-            preprocessed: false,
         }
     }
 }

--- a/resctl-bench-intf/src/jobspec.rs
+++ b/resctl-bench-intf/src/jobspec.rs
@@ -12,8 +12,6 @@ pub struct JobSpec {
 
     #[serde(skip)]
     pub preprocessed: bool,
-    #[serde(skip)]
-    pub forward_results_from: Vec<usize>,
 }
 
 impl std::cmp::PartialEq for JobSpec {
@@ -32,7 +30,6 @@ impl JobSpec {
             id,
             props,
             preprocessed: false,
-            forward_results_from: vec![],
         }
     }
 }

--- a/resctl-bench/src/bench.rs
+++ b/resctl-bench/src/bench.rs
@@ -103,7 +103,7 @@ pub trait Bench: Send + Sync {
         Ok(())
     }
 
-    fn parse(&self, spec: &JobSpec) -> Result<Box<dyn Job>>;
+    fn parse(&self, spec: &JobSpec, prev_data: Option<&JobData>) -> Result<Box<dyn Job>>;
 }
 
 fn register_bench(bench: Box<dyn Bench>) -> () {

--- a/resctl-bench/src/bench.rs
+++ b/resctl-bench/src/bench.rs
@@ -2,7 +2,7 @@
 
 // The individual bench implementations under bench/ inherits all uses from
 // this file. Make common stuff available.
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;

--- a/resctl-bench/src/bench.rs
+++ b/resctl-bench/src/bench.rs
@@ -14,7 +14,7 @@ use super::job::{Job, JobData};
 use super::progress::BenchProgress;
 use super::run::RunCtx;
 use super::study::*;
-use rd_agent_intf::{BenchKnobs, SysReq};
+use rd_agent_intf::SysReq;
 use resctl_bench_intf::{JobProps, JobSpec};
 
 use util::*;
@@ -92,17 +92,6 @@ impl BenchDesc {
 
 pub trait Bench: Send + Sync {
     fn desc(&self) -> BenchDesc;
-
-    fn preprocess_run_specs(
-        &self,
-        _specs: &mut Vec<JobSpec>,
-        _idx: usize,
-        _base_bench: &BenchKnobs,
-        _prev_data: Option<&JobData>,
-    ) -> Result<()> {
-        Ok(())
-    }
-
     fn parse(&self, spec: &JobSpec, prev_data: Option<&JobData>) -> Result<Box<dyn Job>>;
 }
 

--- a/resctl-bench/src/bench/hashd_params.rs
+++ b/resctl-bench/src/bench/hashd_params.rs
@@ -25,7 +25,7 @@ impl Bench for HashdParamsBench {
         BenchDesc::new("hashd-params").takes_run_props()
     }
 
-    fn parse(&self, spec: &JobSpec) -> Result<Box<dyn Job>> {
+    fn parse(&self, spec: &JobSpec, _prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {
         let mut job = HashdParamsJob::default();
 
         for (k, v) in spec.props[0].iter() {

--- a/resctl-bench/src/bench/iocost_params.rs
+++ b/resctl-bench/src/bench/iocost_params.rs
@@ -12,7 +12,7 @@ impl Bench for IoCostParamsBench {
         BenchDesc::new("iocost-params")
     }
 
-    fn parse(&self, _spec: &JobSpec) -> Result<Box<dyn Job>> {
+    fn parse(&self, _spec: &JobSpec, _prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {
         Ok(Box::new(IoCostParamsJob {}))
     }
 }

--- a/resctl-bench/src/bench/iocost_qos.rs
+++ b/resctl-bench/src/bench/iocost_qos.rs
@@ -486,9 +486,9 @@ impl Job for IoCostQoSJob {
     fn run(&mut self, rctx: &mut RunCtx) -> Result<serde_json::Value> {
         let bench = rctx.base_bench().clone();
 
-        let (prev_matches, mut prev_result) = match rctx.prev_data.as_ref() {
+        let (prev_matches, mut prev_result) = match rctx.prev_data() {
             Some(pd) => {
-                let pr = serde_json::from_value::<IoCostQoSResult>(pd.result.clone()).unwrap();
+                let pr = serde_json::from_value::<IoCostQoSResult>(pd.result).unwrap();
                 (self.prev_matches(&pr, &bench), pr)
             }
             None => (

--- a/resctl-bench/src/bench/iocost_qos.rs
+++ b/resctl-bench/src/bench/iocost_qos.rs
@@ -435,7 +435,15 @@ impl Job for IoCostQoSJob {
                 let pr = serde_json::from_value::<IoCostQoSResult>(pd.result).unwrap();
                 (self.prev_matches(&pr, &bench), pr)
             }
-            None => (true, IoCostQoSResult::default()),
+            None => (
+                true,
+                IoCostQoSResult {
+                    base_model: bench.iocost.model.clone(),
+                    base_qos: bench.iocost.qos.clone(),
+                    dither_dist: self.dither_dist,
+                    ..Default::default()
+                },
+            ),
         };
 
         if prev_result.results.len() > 0 {
@@ -464,6 +472,8 @@ impl Job for IoCostQoSJob {
                 .context("Failed to run iocost-params")?;
             }
             bench = rctx.base_bench().clone();
+            prev_result.base_model = bench.iocost.model.clone();
+            prev_result.base_qos = bench.iocost.qos.clone();
         }
 
         // Print out what to do beforehand so that the user can spot errors

--- a/resctl-bench/src/bench/iocost_qos.rs
+++ b/resctl-bench/src/bench/iocost_qos.rs
@@ -83,59 +83,6 @@ impl Bench for IoCostQoSBench {
             .incremental()
     }
 
-    fn preprocess_run_specs(
-        &self,
-        specs: &mut Vec<JobSpec>,
-        idx: usize,
-        base_bench: &BenchKnobs,
-        prev_data: Option<&JobData>,
-    ) -> Result<()> {
-        let prev_result = if prev_data.is_some() {
-            Some(serde_json::from_value::<IoCostQoSResult>(
-                prev_data.as_ref().unwrap().result.clone(),
-            )?)
-        } else {
-            None
-        };
-
-        // Is the bench result available or iocost-params already scheduled?
-        if base_bench.iocost_seq > 0 {
-            debug!("iocost-qos-pre: iocost parameters available");
-            return Ok(());
-        }
-        for i in (0..idx).rev() {
-            if specs[i].kind == "iocost-params" {
-                debug!("iocost-qos-pre: iocost-params already scheduled");
-                return Ok(());
-            }
-        }
-
-        // If prev has all the needed results, we don't need iocost-params.
-        if let Some(pr) = prev_result.as_ref() {
-            // Let the actual job parsing stage take care of it.
-            let job = match IoCostQoSJob::parse(&specs[idx], prev_data) {
-                Ok(job) => job,
-                Err(_) => return Ok(()),
-            };
-
-            if let Ok(()) = job.runs.iter().try_for_each(|ovr| {
-                IoCostQoSJob::find_matching_result(ovr.as_ref(), pr)
-                    .map(|_| ())
-                    .ok_or(anyhow!(""))
-            }) {
-                debug!("iocost-qos-pre: iocost params unavailable but no need to run more benches");
-                return Ok(());
-            }
-        }
-
-        info!("iocost-qos: iocost parameters missing, inserting iocost-params run");
-        specs.insert(
-            idx,
-            resctl_bench_intf::Args::parse_job_spec("iocost-params")?,
-        );
-        Ok(())
-    }
-
     fn parse(&self, spec: &JobSpec, prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {
         Ok(Box::new(IoCostQoSJob::parse(spec, prev_data)?))
     }
@@ -151,7 +98,7 @@ pub struct IoCostQoSRun {
     pub storage: StorageResult,
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Default)]
 pub struct IoCostQoSResult {
     pub base_model: IoCostModelParams,
     pub base_qos: IoCostQoSParams,
@@ -481,35 +428,48 @@ impl Job for IoCostQoSJob {
     }
 
     fn run(&mut self, rctx: &mut RunCtx) -> Result<serde_json::Value> {
-        let bench = rctx.base_bench().clone();
+        let mut bench = rctx.base_bench().clone();
 
         let (prev_matches, mut prev_result) = match rctx.prev_job_data() {
             Some(pd) => {
                 let pr = serde_json::from_value::<IoCostQoSResult>(pd.result).unwrap();
                 (self.prev_matches(&pr, &bench), pr)
             }
-            None => (
-                true,
-                IoCostQoSResult {
-                    base_model: bench.iocost.model.clone(),
-                    base_qos: bench.iocost.qos.clone(),
-                    mem_profile: 0,
-                    dither_dist: self.dither_dist,
-                    results: vec![],
-                    inc_results: vec![],
-                },
-            ),
+            None => (true, IoCostQoSResult::default()),
         };
 
         if prev_result.results.len() > 0 {
             self.mem_profile = prev_result.mem_profile;
         }
 
-        let abs_min_vrate = Self::calc_abs_min_vrate(&rctx.base_bench().iocost.model);
-        let mut nr_to_run = 0;
+        // Do we already have all results in prev? Otherwise, make sure we
+        // have iocost parameters available.
+        if rctx.base_bench().iocost_seq == 0 {
+            let mut has_all = true;
+            for ovr in self.runs.iter_mut() {
+                if Self::find_matching_result(ovr.as_ref(), &prev_result).is_none() {
+                    has_all = false;
+                    break;
+                }
+            }
+
+            if !has_all {
+                info!(
+                    "iocost-qos: iocost parameters missing and !--iocost-from-sys, \
+                     running iocost-params"
+                );
+                rctx.run_nested_job_spec(
+                    &resctl_bench_intf::Args::parse_job_spec("iocost-params").unwrap(),
+                )
+                .context("Failed to run iocost-params")?;
+            }
+            bench = rctx.base_bench().clone();
+        }
 
         // Print out what to do beforehand so that the user can spot errors
         // without waiting for the benches to run.
+        let abs_min_vrate = Self::calc_abs_min_vrate(&rctx.base_bench().iocost.model);
+        let mut nr_to_run = 0;
         for (i, ovr) in self.runs.iter_mut().enumerate() {
             let qos = &bench.iocost.qos;
 
@@ -549,13 +509,6 @@ impl Job for IoCostQoSJob {
         }
 
         if nr_to_run > 0 {
-            if rctx.base_bench().iocost_seq == 0 {
-                bail!(
-                    "iocost-qos: iocost parameters missing, run iocost-params first or \
-                       use --iocost-from-sys"
-                );
-            }
-
             if prev_matches || nr_to_run == self.runs.len() {
                 info!("iocost-qos: {} storage benches to run", nr_to_run);
             } else {

--- a/resctl-bench/src/bench/iocost_qos.rs
+++ b/resctl-bench/src/bench/iocost_qos.rs
@@ -149,7 +149,7 @@ impl Bench for IoCostQoSBench {
         Ok(())
     }
 
-    fn parse(&self, spec: &JobSpec) -> Result<Box<dyn Job>> {
+    fn parse(&self, spec: &JobSpec, _prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {
         Ok(Box::new(IoCostQoSJob::parse(spec)?))
     }
 }

--- a/resctl-bench/src/bench/iocost_qos.rs
+++ b/resctl-bench/src/bench/iocost_qos.rs
@@ -486,7 +486,7 @@ impl Job for IoCostQoSJob {
     fn run(&mut self, rctx: &mut RunCtx) -> Result<serde_json::Value> {
         let bench = rctx.base_bench().clone();
 
-        let (prev_matches, mut prev_result) = match rctx.prev_data() {
+        let (prev_matches, mut prev_result) = match rctx.prev_job_data() {
             Some(pd) => {
                 let pr = serde_json::from_value::<IoCostQoSResult>(pd.result).unwrap();
                 (self.prev_matches(&pr, &bench), pr)

--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -643,7 +643,7 @@ impl Job for IoCostTuneJob {
 
     fn run(&mut self, rctx: &mut RunCtx) -> Result<serde_json::Value> {
         let src: IoCostQoSResult =
-            serde_json::from_value(rctx.find_cur_job_data("iocost-qos").unwrap().result)
+            serde_json::from_value(rctx.find_done_job_data("iocost-qos").unwrap().result)
                 .map_err(|e| anyhow!("failed to parse iocost-qos result ({})", &e))?;
         let mut data = BTreeMap::<DataSel, DataSeries>::default();
 

--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, BTreeSet};
 mod graph;
 
 const DFL_IOCOST_QOS_VRATE_MAX: f64 = 125.0;
-const DFL_IOCOST_QOS_VRATE_INTVS: u32 = 50;
+const DFL_IOCOST_QOS_VRATE_INTVS: u32 = 25;
 const DFL_GRAN: f64 = 0.1;
 const DFL_VRATE_MIN: f64 = 1.0;
 const DFL_VRATE_MAX: f64 = 100.0;
@@ -269,40 +269,6 @@ impl Bench for IoCostTuneBench {
         BenchDesc::new("iocost-tune")
             .takes_run_propsets()
             .takes_format_props()
-    }
-
-    fn preprocess_run_specs(
-        &self,
-        specs: &mut Vec<JobSpec>,
-        idx: usize,
-        _base_bench: &BenchKnobs,
-        _prev_data: Option<&JobData>,
-    ) -> Result<()> {
-        for i in (0..idx).rev() {
-            let sp = &specs[i];
-            if sp.kind == "iocost-qos" {
-                return Ok(());
-            }
-        }
-
-        info!("iocost-tune: iocost-qos run not specified, inserting with preset params");
-
-        let mut extra_args = String::new();
-        for (k, v) in specs[idx].props[0].iter() {
-            if k == "mem-profile" {
-                extra_args += &format!(",{}={}", k, v);
-                break;
-            }
-        }
-
-        specs.insert(
-            idx,
-            resctl_bench_intf::Args::parse_job_spec(&format!(
-                "iocost-qos:vrate-max={},vrate-intvs={}{}",
-                DFL_IOCOST_QOS_VRATE_MAX, DFL_IOCOST_QOS_VRATE_INTVS, extra_args
-            ))?,
-        );
-        Ok(())
     }
 
     fn parse(&self, spec: &JobSpec, _prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {
@@ -642,9 +608,27 @@ impl Job for IoCostTuneJob {
     }
 
     fn run(&mut self, rctx: &mut RunCtx) -> Result<serde_json::Value> {
-        let src: IoCostQoSResult =
-            serde_json::from_value(rctx.find_done_job_data("iocost-qos").unwrap().result)
-                .map_err(|e| anyhow!("failed to parse iocost-qos result ({})", &e))?;
+        let qos_data = match rctx.find_done_job_data("iocost-qos") {
+            Some(v) => v,
+            None => {
+                let mut spec = format!(
+                    "iocost-qos:dither,vrate-max={},vrate-intvs={}",
+                    DFL_IOCOST_QOS_VRATE_MAX, DFL_IOCOST_QOS_VRATE_INTVS,
+                );
+                if self.mem_profile > 0 {
+                    spec += &format!(",mem-profile={}", self.mem_profile);
+                }
+                info!("iocost-tune: iocost-qos run not specified, running the following");
+                info!("iocost-tune: {}", &spec);
+
+                rctx.run_nested_job_spec(&resctl_bench_intf::Args::parse_job_spec(&spec).unwrap())
+                    .context("Failed to run iocost-qos")?;
+                rctx.find_done_job_data("iocost-qos").unwrap()
+            }
+        };
+
+        let src: IoCostQoSResult = serde_json::from_value(qos_data.result)
+            .map_err(|e| anyhow!("failed to parse iocost-qos result ({})", &e))?;
         let mut data = BTreeMap::<DataSel, DataSeries>::default();
 
         if self.mem_profile == 0 {

--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -281,7 +281,6 @@ impl Bench for IoCostTuneBench {
         for i in (0..idx).rev() {
             let sp = &specs[i];
             if sp.kind == "iocost-qos" {
-                specs[idx].forward_results_from.push(i);
                 return Ok(());
             }
         }
@@ -296,7 +295,6 @@ impl Bench for IoCostTuneBench {
             }
         }
 
-        specs[idx].forward_results_from.push(idx);
         specs.insert(
             idx,
             resctl_bench_intf::Args::parse_job_spec(&format!(
@@ -644,8 +642,9 @@ impl Job for IoCostTuneJob {
     }
 
     fn run(&mut self, rctx: &mut RunCtx) -> Result<serde_json::Value> {
-        let src: IoCostQoSResult = serde_json::from_value(rctx.data_forwards.pop().unwrap().result)
-            .map_err(|e| anyhow!("failed to parse iocost-qos result ({})", &e))?;
+        let src: IoCostQoSResult =
+            serde_json::from_value(rctx.find_cur_job_data("iocost-qos").unwrap().result)
+                .map_err(|e| anyhow!("failed to parse iocost-qos result ({})", &e))?;
         let mut data = BTreeMap::<DataSel, DataSeries>::default();
 
         if self.mem_profile == 0 {

--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -305,7 +305,7 @@ impl Bench for IoCostTuneBench {
         Ok(())
     }
 
-    fn parse(&self, spec: &JobSpec) -> Result<Box<dyn Job>> {
+    fn parse(&self, spec: &JobSpec, _prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {
         let mut job = IoCostTuneJob::default();
 
         for (k, v) in spec.props[0].iter() {

--- a/resctl-bench/src/bench/storage.rs
+++ b/resctl-bench/src/bench/storage.rs
@@ -73,7 +73,7 @@ impl Bench for StorageBench {
         BenchDesc::new("storage").takes_run_props()
     }
 
-    fn parse(&self, spec: &JobSpec) -> Result<Box<dyn Job>> {
+    fn parse(&self, spec: &JobSpec, _prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {
         Ok(Box::new(StorageJob::parse(spec)?))
     }
 }

--- a/resctl-bench/src/job.rs
+++ b/resctl-bench/src/job.rs
@@ -369,29 +369,10 @@ impl JobCtxs {
         None
     }
 
-    pub fn find_matching_jctx<'a>(&'a self, spec: &JobSpec) -> Option<&'a JobCtx> {
-        match self.find_matching_jctx_idx(spec) {
-            Some(idx) => Some(&self.vec[idx]),
-            None => None,
-        }
-    }
-
     pub fn pop_matching_jctx(&mut self, spec: &JobSpec) -> Option<JobCtx> {
         match self.find_matching_jctx_idx(spec) {
             Some(idx) => Some(self.vec.remove(idx)),
             None => None,
-        }
-    }
-
-    pub fn find_prev_data<'a>(&'a self, spec: &JobSpec) -> Option<&'a JobData> {
-        let jctx = match self.find_matching_jctx(spec) {
-            Some(jctx) => jctx,
-            None => return None,
-        };
-        if jctx.are_results_compatible(spec) && jctx.data.result_valid() {
-            Some(&jctx.data)
-        } else {
-            None
         }
     }
 

--- a/resctl-bench/src/job.rs
+++ b/resctl-bench/src/job.rs
@@ -148,9 +148,9 @@ impl JobCtx {
         self.incremental || &self.data.spec == other
     }
 
-    pub fn run(&mut self, rctx: &mut RunCtx, mut sysreqs_forward: Option<SysReqs>) -> Result<()> {
+    pub fn run(&mut self, rctx: &mut RunCtx) -> Result<()> {
         rctx.prev_uid.push(self.prev_uid.unwrap());
-        let pdata = rctx.prev_data();
+        let pdata = rctx.prev_job_data();
         if pdata.is_some() && !self.incremental {
             self.data = pdata.unwrap();
             assert!(rctx.prev_uid.pop().unwrap() == self.prev_uid.unwrap());
@@ -172,8 +172,8 @@ impl JobCtx {
             if let Some(rep) = rctx.report_sample() {
                 data.sysreqs.iocost = rep.iocost.clone();
             }
-        } else if sysreqs_forward.is_some() {
-            data.sysreqs = sysreqs_forward.take().unwrap();
+        } else if rctx.sysreqs_forward.is_some() {
+            data.sysreqs = rctx.sysreqs_forward.take().unwrap();
         } else if pdata.is_some() {
             data.sysreqs = rctx
                 .jobs

--- a/resctl-bench/src/job.rs
+++ b/resctl-bench/src/job.rs
@@ -111,9 +111,9 @@ impl JobCtx {
         UID.fetch_add(1, Ordering::Relaxed)
     }
 
-    pub fn with_data(data: JobData) -> Self {
+    pub fn new(spec: &JobSpec) -> Self {
         Self {
-            data,
+            data: JobData::new(spec),
             bench: None,
             job: None,
             incremental: false,
@@ -121,10 +121,6 @@ impl JobCtx {
             prev_uid: None,
             prev_used: false,
         }
-    }
-
-    pub fn new(spec: &JobSpec) -> Self {
-        Self::with_data(JobData::new(spec))
     }
 
     pub fn parse_job_spec(&mut self) -> Result<()> {
@@ -308,6 +304,14 @@ impl JobCtx {
             .format(Box::new(&mut buf), data, mode == Mode::Format, props)?;
 
         Ok(buf)
+    }
+
+    pub fn print(&self, mode: Mode, props: &JobProps) -> Result<()> {
+        // Format only the completed jobs.
+        if self.data.result_valid() {
+            println!("{}\n\n{}", "=".repeat(90), &self.format(mode, props)?);
+        }
+        Ok(())
     }
 }
 

--- a/resctl-bench/src/main.rs
+++ b/resctl-bench/src/main.rs
@@ -224,35 +224,8 @@ impl Program {
             }
         };
 
-        // Spec preprocessing gives the bench implementations a chance to
-        // add, remove and modify the scheduled benches. Preprocess is
-        // called once per scheduled bench.
-        let mut jobs = self.jobs.lock().unwrap();
-        let args = &mut self.args_file.data;
-        loop {
-            let mut idx = None;
-            for (i, spec) in args.job_specs.iter().enumerate() {
-                if !spec.preprocessed {
-                    idx = Some(i);
-                    break;
-                }
-            }
-            if idx.is_none() {
-                break;
-            }
-
-            let idx = idx.unwrap();
-            let spec = &mut args.job_specs[idx];
-            let prev_data = jobs.prev.find_prev_data(spec);
-            spec.preprocessed = true;
-
-            bench::find_bench(&spec.kind)
-                .unwrap()
-                .preprocess_run_specs(&mut args.job_specs, idx, &base_bench, prev_data)
-                .expect("preprocess_run_specs() failed");
-        }
-
         // Collect the pending jobs.
+        let mut jobs = self.jobs.lock().unwrap();
         let mut pending = JobCtxs::default();
         let args = &self.args_file.data;
         for spec in args.job_specs.iter() {

--- a/resctl-bench/src/main.rs
+++ b/resctl-bench/src/main.rs
@@ -35,18 +35,22 @@ pub struct Jobs {
 impl Jobs {
     pub fn parse_job_spec_and_link(&mut self, spec: &JobSpec) -> Result<JobCtx> {
         let mut new = JobCtx::new(spec);
-        new.parse_job_spec()?;
-        match self.prev.find_matching_unused_jctx_mut(&new.data.spec) {
+        let prev = match self.prev.find_matching_unused_jctx_mut(spec) {
             Some(prev) => {
                 debug!("{} has a matching entry in the result file", &new.data.spec);
                 prev.prev_used = true;
                 new.prev_uid = Some(prev.uid);
+                Some(prev)
             }
-            None => {
-                let clone = new.clone();
-                new.prev_uid = Some(clone.uid);
-                self.prev.vec.push(clone);
-            }
+            None => None,
+        };
+
+        new.parse_job_spec(prev.as_ref().map_or(None, |p| Some(&p.data)))?;
+
+        if prev.is_none() {
+            let clone = new.weak_clone();
+            new.prev_uid = Some(clone.uid);
+            self.prev.vec.push(clone);
         }
         Ok(new)
     }

--- a/resctl-bench/src/main.rs
+++ b/resctl-bench/src/main.rs
@@ -304,20 +304,9 @@ impl Program {
                 panic!();
             }
 
-            let mut data_forwards = vec![];
-            let mut sysreqs_forward = None;
-            for i in jctx.data.spec.forward_results_from.iter() {
-                let jobs = self.jobs.lock().unwrap();
-                let from = &jobs.cur.vec[*i];
-                data_forwards.push(from.data.clone());
-                if sysreqs_forward.is_none() {
-                    sysreqs_forward = Some(from.data.sysreqs.clone());
-                }
-            }
+            let mut rctx = RunCtx::new(&args, &base_bench, self.jobs.clone());
 
-            let mut rctx = RunCtx::new(&args, &base_bench, self.jobs.clone(), data_forwards);
-
-            if let Err(e) = jctx.run(&mut rctx, sysreqs_forward) {
+            if let Err(e) = jctx.run(&mut rctx) {
                 error!("Failed to run {} ({})", &jctx.data.spec, &e);
                 panic!();
             }

--- a/resctl-bench/src/run.rs
+++ b/resctl-bench/src/run.rs
@@ -11,7 +11,7 @@ use util::*;
 
 use super::progress::BenchProgress;
 use super::{Program, AGENT_BIN};
-use crate::job::{JobCtx, JobData};
+use crate::job::{JobCtx, JobCtxs, JobData};
 use rd_agent_intf::{
     AgentFiles, ReportIter, RunnerState, Slice, SysReq, AGENT_SVC_NAME, HASHD_BENCH_SVC_NAME,
     IOCOST_BENCH_SVC_NAME,
@@ -153,7 +153,7 @@ pub struct RunCtx<'a> {
     base_bench: rd_agent_intf::BenchKnobs,
     pub prev_data: Option<JobData>,
     pub data_forwards: Vec<JobData>,
-    inc_job_ctxs: &'a mut Vec<JobCtx>,
+    inc_jctxs: &'a mut JobCtxs,
     inc_job_idx: usize,
     result_path: &'a str,
     pub test: bool,
@@ -164,7 +164,7 @@ impl<'a> RunCtx<'a> {
     pub fn new(
         args: &'a resctl_bench_intf::Args,
         base_bench: &rd_agent_intf::BenchKnobs,
-        inc_job_ctxs: &'a mut Vec<JobCtx>,
+        inc_jctxs: &'a mut JobCtxs,
         inc_job_idx: usize,
         data_forwards: Vec<JobData>,
     ) -> Self {
@@ -193,7 +193,7 @@ impl<'a> RunCtx<'a> {
             agent_init_fns: vec![],
             prev_data: None,
             data_forwards,
-            inc_job_ctxs,
+            inc_jctxs,
             inc_job_idx,
             result_path: &args.result,
             test: args.test,
@@ -249,13 +249,13 @@ impl<'a> RunCtx<'a> {
     }
 
     pub fn update_incremental_jctx(&mut self, jctx: &JobCtx) {
-        self.inc_job_ctxs[self.inc_job_idx] = jctx.clone();
-        Program::save_results(self.result_path, self.inc_job_ctxs);
+        self.inc_jctxs.vec[self.inc_job_idx] = jctx.clone();
+        self.inc_jctxs.save_results(self.result_path);
     }
 
     pub fn update_incremental_result(&mut self, result: serde_json::Value) {
-        self.inc_job_ctxs[self.inc_job_idx].data.result = result;
-        Program::save_results(self.result_path, self.inc_job_ctxs);
+        self.inc_jctxs.vec[self.inc_job_idx].data.result = result;
+        self.inc_jctxs.save_results(self.result_path);
     }
 
     pub fn base_bench(&self) -> &rd_agent_intf::BenchKnobs {


### PR DESCRIPTION
Previously, when a bench needed the result from another bench, it had to insert the spec for the nested bench into the scheduled specs list from the preprocess hook before bench runs start. This was inflexible (can't make dynamic decisions) and often required duplicate parsing and other processing. This pull modularizes job handling, implements nested execution support and replace preprocessing with straight-forward nested runs.