### PR TITLE
Revert "bench: lower ABS_MIN_IO_PERF"

### DIFF
--- a/resctl-bench/src/bench/iocost_qos.rs
+++ b/resctl-bench/src/bench/iocost_qos.rs
@@ -482,7 +482,6 @@ impl Job for IoCostQoSJob {
         // Mark the ones with too low a max rate to run.
         if !self.ign_min_perf {
             let abs_min_vrate = iocost_min_vrate(&bench_knobs.iocost.model);
-            debug!("iocost-qos: abs_min_vrate={:.2}", abs_min_vrate);
             for ovr in self.runs.iter_mut() {
                 ovr.skip_or_adj(abs_min_vrate);
             }

--- a/resctl-bench/src/iocost.rs
+++ b/resctl-bench/src/iocost.rs
@@ -9,12 +9,12 @@ pub use resctl_bench_intf::iocost::*;
 // seqiops are artificially lowered to avoid limiting throttling of older
 // SSDs which have similar seqiops as hard drives.
 pub const ABS_MIN_IO_PERF: IoCostModelParams = IoCostModelParams {
-    rbps: 60 << 20,
-    rseqiops: 160,
-    rrandiops: 160,
-    wbps: 60 << 20,
-    wseqiops: 160,
-    wrandiops: 160,
+    rbps: 125 << 20,
+    rseqiops: 280,
+    rrandiops: 280,
+    wbps: 125 << 20,
+    wseqiops: 280,
+    wrandiops: 280,
 };
 
 pub fn iocost_min_vrate(model: &IoCostModelParams) -> f64 {


### PR DESCRIPTION
This reverts commit bf6c9bc2fbfcec138eca7753067069c68218f705.

The lowered floor introduces another inflection point in some graphs
confusing line fitting. If we wanna support slow hard drives, the right
thing to do would be applying lowered min perf to only hard drives.