### PR TITLE
Make the result file an option instead of a positional argument

### DIFF
--- a/resctl-bench-intf/src/args.rs
+++ b/resctl-bench-intf/src/args.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::exit;
+use std::sync::Mutex;
 use util::*;
 
 use super::{IoCostQoSOvr, JobSpec};
@@ -40,6 +41,13 @@ lazy_static::lazy_static! {
             dfl_systemd_timeout = format_duration(dfl_args.systemd_timeout),
         )
     };
+    pub static ref AFTER_HELP: Mutex<&'static str> = Mutex::new("");
+}
+
+pub fn set_after_help(help: &str)
+{
+    let help = Box::new(help.to_string());
+    *AFTER_HELP.lock().unwrap() = Box::leak(help);
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -373,8 +381,7 @@ impl JsonArgs for Args {
                             .long("multiple")
                             .help("Allow more than one result per kind (and optionally id)")
                     )
-            )
-            .get_matches()
+            ).after_help(*AFTER_HELP.lock().unwrap()).get_matches()
     }
 
     fn verbosity(matches: &clap::ArgMatches) -> u32 {

--- a/resctl-bench-intf/src/lib.rs
+++ b/resctl-bench-intf/src/lib.rs
@@ -5,7 +5,7 @@ pub mod args;
 pub mod iocost;
 pub mod jobspec;
 
-pub use args::{set_after_help, Args, Mode};
+pub use args::{set_bench_list, Args, Mode};
 pub use iocost::IoCostQoSOvr;
 pub use jobspec::{format_job_props, JobProps, JobSpec};
 

--- a/resctl-bench-intf/src/lib.rs
+++ b/resctl-bench-intf/src/lib.rs
@@ -5,7 +5,7 @@ pub mod args;
 pub mod iocost;
 pub mod jobspec;
 
-pub use args::{Args, Mode};
+pub use args::{set_after_help, Args, Mode};
 pub use iocost::IoCostQoSOvr;
 pub use jobspec::{format_job_props, JobProps, JobSpec};
 

--- a/resctl-bench/src/bench.rs
+++ b/resctl-bench/src/bench.rs
@@ -100,7 +100,6 @@ pub fn find_bench(kind: &str) -> Result<Arc<Box<dyn Bench>>> {
 
 pub fn bench_list() -> String {
     let mut buf = String::new();
-    writeln!(buf, "BENCHMARKS:").unwrap();
 
     let descs: Vec<BenchDesc> = BENCHS
         .lock()
@@ -220,8 +219,8 @@ pub fn init_benchs() -> () {
     register_bench(Box::new(storage::StorageBench {}));
     register_bench(Box::new(iocost_params::IoCostParamsBench {}));
     register_bench(Box::new(hashd_params::HashdParamsBench {}));
-    register_bench(Box::new(iocost_qos::IoCostQoSBench {}));
     register_bench(Box::new(protection::ProtectionBench {}));
+    register_bench(Box::new(iocost_qos::IoCostQoSBench {}));
     register_bench(Box::new(iocost_tune::IoCostTuneBench {}));
     register_bench(Box::new(merge_info::MergeInfoBench {}));
 }

--- a/resctl-bench/src/bench.rs
+++ b/resctl-bench/src/bench.rs
@@ -98,9 +98,43 @@ pub fn find_bench(kind: &str) -> Result<Arc<Box<dyn Bench>>> {
     bail!("unknown bench kind {:?}", kind);
 }
 
+pub fn bench_list() -> String {
+    let mut buf = String::new();
+    writeln!(buf, "BENCHMARKS:").unwrap();
+
+    let descs: Vec<BenchDesc> = BENCHS
+        .lock()
+        .unwrap()
+        .iter()
+        .filter_map(|bench| {
+            let desc = bench.desc();
+            if desc.about.len() > 0 {
+                Some(desc)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let kind_width = descs.iter().map(|desc| desc.kind.len()).max().unwrap_or(0);
+
+    for desc in descs.iter() {
+        writeln!(
+            buf,
+            "    {:width$}    {}",
+            &desc.kind,
+            &desc.about,
+            width = kind_width
+        )
+        .unwrap();
+    }
+    buf
+}
+
 #[derive(Default)]
 pub struct BenchDesc {
     pub kind: String,
+    pub about: String,
     pub takes_run_props: bool,
     pub takes_run_propsets: bool,
     pub takes_format_props: bool,
@@ -113,9 +147,10 @@ pub struct BenchDesc {
 
 #[allow(dead_code)]
 impl BenchDesc {
-    pub fn new(kind: &str) -> Self {
+    pub fn new(kind: &str, about: &str) -> Self {
         Self {
             kind: kind.into(),
+            about: about.into(),
             ..Default::default()
         }
     }
@@ -186,7 +221,7 @@ pub fn init_benchs() -> () {
     register_bench(Box::new(iocost_params::IoCostParamsBench {}));
     register_bench(Box::new(hashd_params::HashdParamsBench {}));
     register_bench(Box::new(iocost_qos::IoCostQoSBench {}));
-    register_bench(Box::new(iocost_tune::IoCostTuneBench {}));
     register_bench(Box::new(protection::ProtectionBench {}));
+    register_bench(Box::new(iocost_tune::IoCostTuneBench {}));
     register_bench(Box::new(merge_info::MergeInfoBench {}));
 }

--- a/resctl-bench/src/bench/hashd_params.rs
+++ b/resctl-bench/src/bench/hashd_params.rs
@@ -30,7 +30,7 @@ pub struct HashdParamsBench {}
 
 impl Bench for HashdParamsBench {
     fn desc(&self) -> BenchDesc {
-        BenchDesc::new("hashd-params").takes_run_props()
+        BenchDesc::new("hashd-params", "Benchmark rd-hashd parameters").takes_run_props()
     }
 
     fn parse(&self, spec: &JobSpec, _prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {

--- a/resctl-bench/src/bench/iocost_params.rs
+++ b/resctl-bench/src/bench/iocost_params.rs
@@ -9,7 +9,7 @@ pub struct IoCostParamsBench {}
 
 impl Bench for IoCostParamsBench {
     fn desc(&self) -> BenchDesc {
-        BenchDesc::new("iocost-params")
+        BenchDesc::new("iocost-params", "Benchmark io.cost model parameters")
     }
 
     fn parse(&self, _spec: &JobSpec, _prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {

--- a/resctl-bench/src/bench/iocost_qos.rs
+++ b/resctl-bench/src/bench/iocost_qos.rs
@@ -38,10 +38,13 @@ pub struct IoCostQoSBench {}
 
 impl Bench for IoCostQoSBench {
     fn desc(&self) -> BenchDesc {
-        BenchDesc::new("iocost-qos")
-            .takes_run_propsets()
-            .takes_format_props()
-            .incremental()
+        BenchDesc::new(
+            "iocost-qos",
+            "Benchmark IO isolation with different io.cost QoS configurations",
+        )
+        .takes_run_propsets()
+        .takes_format_props()
+        .incremental()
     }
 
     fn parse(&self, spec: &JobSpec, prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {

--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -775,12 +775,15 @@ pub struct IoCostTuneBench {}
 
 impl Bench for IoCostTuneBench {
     fn desc(&self) -> BenchDesc {
-        BenchDesc::new("iocost-tune")
-            .takes_run_propsets()
-            .takes_format_props()
-            .incremental()
-            .mergeable()
-            .merge_needs_storage_model()
+        BenchDesc::new(
+            "iocost-tune",
+            "Benchmark storage device to determine io.cost QoS solutions",
+        )
+        .takes_run_propsets()
+        .takes_format_props()
+        .incremental()
+        .mergeable()
+        .merge_needs_storage_model()
     }
 
     fn parse(&self, spec: &JobSpec, _prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {

--- a/resctl-bench/src/bench/merge_info.rs
+++ b/resctl-bench/src/bench/merge_info.rs
@@ -8,7 +8,7 @@ pub struct MergeInfoBench {}
 
 impl Bench for MergeInfoBench {
     fn desc(&self) -> BenchDesc {
-        BenchDesc::new("merge-info")
+        BenchDesc::new("merge-info", "")
     }
 
     fn parse(&self, _spec: &JobSpec, _prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {

--- a/resctl-bench/src/bench/protection.rs
+++ b/resctl-bench/src/bench/protection.rs
@@ -214,7 +214,7 @@ pub struct ProtectionBench {}
 
 impl Bench for ProtectionBench {
     fn desc(&self) -> BenchDesc {
-        BenchDesc::new("protection").takes_run_propsets()
+        BenchDesc::new("protection", "Benchmark resource protection").takes_run_propsets()
     }
 
     fn parse(&self, spec: &JobSpec, _prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {

--- a/resctl-bench/src/bench/storage.rs
+++ b/resctl-bench/src/bench/storage.rs
@@ -47,7 +47,7 @@ pub struct StorageBench {}
 
 impl Bench for StorageBench {
     fn desc(&self) -> BenchDesc {
-        BenchDesc::new("storage").takes_run_props()
+        BenchDesc::new("storage", "Benchmark storage device with rd-hashd").takes_run_props()
     }
 
     fn parse(&self, spec: &JobSpec, _prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {

--- a/resctl-bench/src/main.rs
+++ b/resctl-bench/src/main.rs
@@ -353,6 +353,7 @@ impl Program {
                     panic!();
                 }
             }
+            Mode::Doc => {}
         }
     }
 }
@@ -362,7 +363,7 @@ fn main() {
     setup_prog_state();
     bench::init_benchs();
 
-    resctl_bench_intf::set_after_help(&bench::bench_list());
+    resctl_bench_intf::set_bench_list(&bench::bench_list());
     let (args_file, args_updated) = Args::init_args_and_logging_nosave().unwrap_or_else(|e| {
         error!("Failed to process args file ({})", &e);
         panic!();

--- a/resctl-bench/src/main.rs
+++ b/resctl-bench/src/main.rs
@@ -362,6 +362,7 @@ fn main() {
     setup_prog_state();
     bench::init_benchs();
 
+    resctl_bench_intf::set_after_help(&bench::bench_list());
     let (args_file, args_updated) = Args::init_args_and_logging_nosave().unwrap_or_else(|e| {
         error!("Failed to process args file ({})", &e);
         panic!();


### PR DESCRIPTION
This avoid the clap bug around positional argument and subcommand and prepares for "doc" subcommand which won't need the result file specified.