### PR TITLE
bench: make benchmarks more resilient

### DIFF
--- a/resctl-bench/src/job.rs
+++ b/resctl-bench/src/job.rs
@@ -419,14 +419,18 @@ impl JobCtx {
                     .data
                     .sysinfo
                     .clone();
-            } else {
+            }
+
+            if rctx.sysreqs_report().is_none() {
                 warn!(
                     "job: No sysreqs available for {:?} after completion, cycling rd_agent...",
                     &data.spec
                 );
-                rctx.start_agent(vec![])?;
+                let saved_cfg = rctx.reset_cfg(None);
+                rctx.skip_mem_profile().start_agent(vec![])?;
                 rctx.stop_agent();
                 Self::fill_sysinfo_from_rctx(&mut data.sysinfo, rctx);
+                rctx.reset_cfg(Some(saved_cfg));
             }
 
             data.record = Some(record);

--- a/resctl-bench/src/study/iolat.rs
+++ b/resctl-bench/src/study/iolat.rs
@@ -10,7 +10,11 @@ pub fn sel_factory_iolat(io_type: &str, pct: &str) -> impl FnMut(&SelArg) -> Vec
     let io_type = io_type.to_string();
     let pct = pct.to_string();
     move |arg: &SelArg| {
-        if arg.rep.iolat.map[&io_type]["100"] > 0.0 {
+        let map = &arg.rep.iolat.map;
+        if map.contains_key(&io_type)
+            && map[&io_type].contains_key(&pct)
+            && map[&io_type]["100"] > 0.0
+        {
             vec![arg.rep.iolat.map[&io_type][&pct]]
         } else {
             vec![]


### PR DESCRIPTION
* I'm not sure how it happened but study code panicked on incomplete iolat
  map. Make the code check the latency being read is actually available.

* If an incremental benchmark fails while computing the result after all
  steps are complete, the result produced after running it again ends up
  with no sysreqs_report because rd-agent is never started on the run which
  produces the result. The generic code has a fallback code to cycle
  rd-agent to produce sysreqs_report for such cases but it wasn't being
  activated correctly. Fix it.