### PR TITLE
Improve [rb-]bench.json handling

### DIFF
--- a/resctl-bench-intf/src/jobspec.rs
+++ b/resctl-bench-intf/src/jobspec.rs
@@ -39,8 +39,6 @@ pub struct JobSpec {
     pub props: JobProps,
 }
 
-impl std::cmp::Eq for JobSpec {}
-
 impl JobSpec {
     pub fn props(input: &[&[(&str, &str)]]) -> Vec<BTreeMap<String, String>> {
         if input.len() == 0 {
@@ -65,6 +63,18 @@ impl JobSpec {
             passive: passive.map(Into::into),
             props,
         }
+    }
+
+    pub fn compatible(&self, other: &Self) -> bool {
+        const IGN_PROP_KEYS: &[&'static str] = &["apply", "commit"];
+        let mut left = self.clone();
+        let mut right = other.clone();
+
+        for key in IGN_PROP_KEYS.iter() {
+            left.props[0].remove(*key);
+            right.props[0].remove(*key);
+        }
+        left == right
     }
 }
 

--- a/resctl-bench/src/bench/iocost_qos.rs
+++ b/resctl-bench/src/bench/iocost_qos.rs
@@ -98,7 +98,7 @@ impl IoCostQoSJob {
             "storage",
             None,
             Some(format!("none,{}", spec.passive.as_deref().unwrap_or("")).trim_end_matches(',')),
-            JobSpec::props(&[]),
+            JobSpec::props(&[&[("commit", "")]]),
         );
         let mut prot_spec = JobSpec::new(
             "protection",
@@ -348,15 +348,8 @@ impl IoCostQoSJob {
         )
         .context("Parsing storage result")?;
 
-        // Stash the bench result for the protection runs. This needs to be
-        // done manually because storage bench runs use fake-cpu-load which
-        // don't get committed to the base bench.
-        rctx.load_bench_knobs()?;
-
-        // Run the protection bench. The saved bench result is of the last
-        // run of the storage bench. Update it with the current mean size.
-        rctx.set_hashd_mem_size(stor_res.mem_size)?;
-
+        // Run the protection bench with the hashd params committed by the
+        // storage bench.
         qos_cfg.apply(rctx);
         Self::set_prot_size_range(pjob, &stor_rec, &stor_res);
 

--- a/resctl-bench/src/bench/iocost_qos.rs
+++ b/resctl-bench/src/bench/iocost_qos.rs
@@ -98,7 +98,7 @@ impl IoCostQoSJob {
             "storage",
             None,
             Some(format!("none,{}", spec.passive.as_deref().unwrap_or("")).trim_end_matches(',')),
-            JobSpec::props(&[&[("commit", "")]]),
+            JobSpec::props(&[&[("apply", "")]]),
         );
         let mut prot_spec = JobSpec::new(
             "protection",

--- a/resctl-bench/src/bench/protection/mem_hog_tune.rs
+++ b/resctl-bench/src/bench/protection/mem_hog_tune.rs
@@ -54,7 +54,7 @@ impl MemHogTune {
     ) -> Result<(bool, Option<MemHogRecord>)> {
         let started_at = unix_now();
 
-        rctx.set_hashd_mem_size(size)?;
+        rctx.set_hashd_mem_size(size, false)?;
         let base_rps = rctx.bench_knobs().hashd.rps_max as f64 * self.load;
         let fail_pct = self.isol_pct.parse::<f64>().unwrap() / 100.0;
         let early_fail_cnt = (self.dur * fail_pct).ceil() as u64;

--- a/resctl-bench/src/job.rs
+++ b/resctl-bench/src/job.rs
@@ -518,7 +518,7 @@ impl JobCtxs {
             if !jctx.used
                 && jctx.data.spec.kind == spec.kind
                 && jctx.data.spec.id == spec.id
-                && (jctx.incremental || &jctx.data.spec == spec)
+                && (jctx.incremental || jctx.data.spec.compatible(spec))
             {
                 return Some(jctx);
             }

--- a/resctl-bench/src/main.rs
+++ b/resctl-bench/src/main.rs
@@ -143,7 +143,8 @@ impl Program {
         }
 
         for jctx in pending.vec.iter() {
-            base.all_sysreqs.extend(jctx.job.as_ref().unwrap().sysreqs());
+            base.all_sysreqs
+                .extend(jctx.job.as_ref().unwrap().sysreqs());
         }
 
         debug!(

--- a/util/src/iocost.rs
+++ b/util/src/iocost.rs
@@ -17,6 +17,16 @@ pub struct IoCostModelParams {
     pub wrandiops: u64,
 }
 
+impl std::fmt::Display for IoCostModelParams {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "rbps={} rseqiops={} rrandiops={} wbps={} wseqiops={} wrandiops={}",
+            self.rbps, self.rseqiops, self.rrandiops, self.wbps, self.wseqiops, self.wrandiops
+        )
+    }
+}
+
 impl std::ops::Mul<f64> for IoCostModelParams {
     type Output = Self;
 


### PR DESCRIPTION
Improve how bench params are applied and committed persistently so that it's simpler and consistent across different benchmarks and the result from e.g. storage bench can be easily applied to subsequent benchmarks.