### PR TITLE
bench: iocost-qos: fix QoS override applications

### DIFF
--- a/resctl-bench/src/base.rs
+++ b/resctl-bench/src/base.rs
@@ -23,6 +23,7 @@ pub struct Base<'a> {
     pub scr_devname: String,
     pub bench_knobs_path: String,
     pub demo_bench_knobs_path: String,
+    pub saved_bench_knobs: BenchKnobs,
     pub bench_knobs: BenchKnobs,
     pub mem: MemInfo,
     pub mem_initialized: bool,
@@ -159,6 +160,7 @@ impl<'a> Base<'a> {
             scr_devname,
             bench_knobs_path: args.bench_knobs_path(),
             demo_bench_knobs_path: args.demo_bench_knobs_path(),
+            saved_bench_knobs: bench_knobs.clone(),
             bench_knobs,
             mem: MemInfo {
                 profile: args.mem_profile.unwrap_or(0),
@@ -177,6 +179,7 @@ impl<'a> Base<'a> {
             scr_devname: "".to_owned(),
             bench_knobs_path: "".to_owned(),
             demo_bench_knobs_path: "".to_owned(),
+            saved_bench_knobs: Default::default(),
             bench_knobs: Default::default(),
             mem: Default::default(),
             mem_initialized: true,
@@ -253,6 +256,10 @@ impl<'a> Base<'a> {
             },
             commit,
         )
+    }
+
+    pub fn revert_bench_knobs(&mut self) -> Result<()> {
+        self.apply_bench_knobs(self.saved_bench_knobs.clone(), false)
     }
 
     pub fn initialize(&self) -> Result<()> {

--- a/resctl-bench/src/bench/iocost_qos.rs
+++ b/resctl-bench/src/bench/iocost_qos.rs
@@ -318,7 +318,7 @@ impl IoCostQoSJob {
         let mut tries = 0;
         let rec_json = loop {
             tries += 1;
-            qos_cfg.apply(rctx);
+            qos_cfg.apply(rctx)?;
             let r = sjob.clone().run(rctx);
             rctx.stop_agent();
             match r {
@@ -350,7 +350,7 @@ impl IoCostQoSJob {
 
         // Run the protection bench with the hashd params committed by the
         // storage bench.
-        qos_cfg.apply(rctx);
+        qos_cfg.apply(rctx)?;
         Self::set_prot_size_range(pjob, &stor_rec, &stor_res);
 
         let out = pjob.run(rctx);
@@ -455,6 +455,9 @@ impl Job for IoCostQoSJob {
     }
 
     fn run(&mut self, rctx: &mut RunCtx) -> Result<serde_json::Value> {
+        // We'll be changing bench params mutliples times, revert when done.
+        rctx.set_revert_bench();
+
         // Make sure we have iocost parameters available.
         let mut bench_knobs = rctx.bench_knobs().clone();
         if bench_knobs.iocost_seq == 0 {

--- a/resctl-bench/src/iocost.rs
+++ b/resctl-bench/src/iocost.rs
@@ -1,5 +1,8 @@
 use super::run::RunCtx;
+use anyhow::Result;
 use util::*;
+
+use rd_agent_intf::IoCostKnobs;
 
 pub use resctl_bench_intf::iocost::*;
 
@@ -71,28 +74,36 @@ impl<'a, 'b> IoCostQoSCfg<'a, 'b> {
         Some(qos)
     }
 
-    /// Set up init function to configure qos after agent startup.
-    pub fn apply(&self, rctx: &mut RunCtx) {
-        let qos = self.calc();
+    pub fn apply(&self, rctx: &mut RunCtx) -> Result<()> {
+        // This should be called before rctx is started.
+        assert!(!rctx.agent_running());
+
+        // Apply the calculated QoS paramters.
+        let enable = match self.calc() {
+            Some(qos) => {
+                rctx.apply_iocost_knobs(
+                    IoCostKnobs {
+                        qos,
+                        ..rctx.bench_knobs().iocost.clone()
+                    },
+                    false,
+                )?;
+                true
+            }
+            None => false,
+        };
+
+        // Setup an init function to enable/disable IO control.
         rctx.add_agent_init_fn(move |rctx| {
             rctx.access_agent_files(|af| {
-                let bench = &mut af.bench.data;
                 let slices = &mut af.slices.data;
                 let rep = &af.report.data;
-                match qos.as_ref() {
-                    Some(qos) => {
-                        slices.disable_seqs.io = 0;
-                        bench.iocost.qos = qos.clone();
-                        af.bench.save().unwrap();
-                        af.slices.save().unwrap();
-                    }
-                    None => {
-                        slices.disable_seqs.io = rep.seq;
-                        af.slices.save().unwrap();
-                    }
-                }
-            });
+                slices.disable_seqs.io = if enable { 0 } else { rep.seq };
+                af.slices.save().unwrap();
+            })
         });
+
+        Ok(())
     }
 
     pub fn format(&self) -> String {


### PR DESCRIPTION
QoS overrides are clobbered by set_hashd_mem_size() because they were being
applied without updating the rctx's base QoS params. Fix it by always
applying through rctx. While at it, add bench param revert mechanism and
make iocost-qos use it as iocost-qos applies multiple different hashd and
iocost QoS parameters and we don't wanna keep them applied afterwards.