### PR TITLE
agent: make python shebangs consistent

### DIFF
--- a/rd-agent/src/misc/biolatpcts.py
+++ b/rd-agent/src/misc/biolatpcts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # @nolint
 # fmt: off

--- a/rd-agent/src/side/memory-balloon.py
+++ b/rd-agent/src/side/memory-balloon.py
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/python3
 # Copyright (c) Facebook, Inc. and its affiliates
 
 import mmap

--- a/rd-agent/src/side/read-bomb.py
+++ b/rd-agent/src/side/read-bomb.py
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/python3
 # Copyright (c) Facebook, Inc. and its affiliates
 
 import math


### PR DESCRIPTION
Some distros are getting rid of un-versioned python alias.