### PR TITLE
agent: inodesteal-test.py: bump inactive page cache size

### DIFF
--- a/rd-agent/src/side/inodesteal-test.py
+++ b/rd-agent/src/side/inodesteal-test.py
@@ -59,7 +59,7 @@ def one_round(inodesteal_target, prefix):
 
     # Add some inactive page cache.
     with open(TF_DIR + "/inactive", "w+") as f:
-        f.truncate(target_swap)
+        f.truncate(2 * target_swap)
         f.read()
 
     # Balloon up in 256M increments until swap_free falls below target_swap_free.


### PR DESCRIPTION
inodesteal-test.py was prone to incorrectly report success inside VMs. Bump
inactive page cache size. This seems to make the detection a lot more
reliable.