### PR TITLE
Bump sysinfo to 0.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1620,7 +1620,7 @@ dependencies = [
  "scan_fmt",
  "serde",
  "serde_json",
- "sysinfo 0.16.5",
+ "sysinfo",
  "users",
 ]
 
@@ -1704,7 +1704,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simplelog",
- "sysinfo 0.16.5",
+ "sysinfo",
  "vergen",
 ]
 
@@ -2056,22 +2056,6 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.16.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567e910ef0207be81a4e1bb0491e9a8d9866cf45b20fe1a52c03d347da9ea51b"
-dependencies = [
- "cfg-if 1.0.0",
- "core-foundation-sys",
- "doc-comment",
- "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "winapi",
-]
-
-[[package]]
-name = "sysinfo"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d404aefa651a24a7f2a1190fec9fb6380ba84ac511a6fefad79eb0e63d39a97d"
@@ -2082,6 +2066,7 @@ dependencies = [
  "libc",
  "ntapi",
  "once_cell",
+ "rayon",
  "winapi",
 ]
 
@@ -2304,7 +2289,7 @@ dependencies = [
  "git2",
  "rustc_version",
  "rustversion",
- "sysinfo 0.18.2",
+ "sysinfo",
  "thiserror",
 ]
 

--- a/rd-agent/Cargo.toml
+++ b/rd-agent/Cargo.toml
@@ -33,5 +33,5 @@ regex = "^1.4"
 scan_fmt = "^0.2"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
-sysinfo = "^0.16"
+sysinfo = "^0.18"
 users = "^0.11"

--- a/rd-util/Cargo.toml
+++ b/rd-util/Cargo.toml
@@ -34,7 +34,7 @@ scan_fmt = "^0.2"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 simplelog = "^0.10"
-sysinfo = "^0.16"
+sysinfo = "^0.18"
 
 [build-dependencies]
 anyhow = "^1.0"


### PR DESCRIPTION
Needed to package `resctl-demo` in Fedora. `cargo test` still passes.