### PR TITLE
agent: restore iosched on exit and don't override it if passive=io

### DIFF
--- a/rd-agent/src/cmd.rs
+++ b/rd-agent/src/cmd.rs
@@ -471,15 +471,17 @@ impl Runner {
                     warn!("cmd: Health check failed ({:?})", &e);
                 }
 
-                let iosched = match data.state {
-                    BenchIoCost => "none",
-                    _ => "mq-deadline",
-                };
-                if let Err(e) = super::set_iosched(&data.cfg.scr_dev, iosched) {
-                    error!(
-                        "cfg: Failed to set {:?} iosched on {:?} ({})",
-                        iosched, &data.cfg.scr_dev, &e
-                    );
+                if data.cfg.enforce.io {
+                    let iosched = match data.state {
+                        BenchIoCost => "none",
+                        _ => "mq-deadline",
+                    };
+                    if let Err(e) = super::set_iosched(&data.cfg.scr_dev, iosched) {
+                        error!(
+                            "cfg: Failed to set {:?} iosched on {:?} ({})",
+                            iosched, &data.cfg.scr_dev, &e
+                        );
+                    }
                 }
 
                 last_health_check_at = now;


### PR DESCRIPTION
rd-agent was overwriting iosched unconditionally and didn't restore them
afterwards. Fix it.