### PR TITLE
Update cursive to 0.16 and use the new features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,11 +25,13 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.4.7"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+checksum = "796540673305a66d127804eef19ad696f1f204b8c1025aaca4958c17eab32877"
 dependencies = [
- "const-random",
+ "getrandom 0.2.3",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
@@ -113,7 +115,7 @@ checksum = "b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -140,12 +142,6 @@ checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 dependencies = [
  "jobserver",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -207,28 +203,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-random"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f590d95d011aa80b063ffe3253422ed5aa462af4e9867d43ce8337562bac77c4"
-dependencies = [
- "const-random-macro",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615f6e27d000a2bffbc7f2f6a8669179378fa27ee4d0a509e985dfc0a7defb40"
-dependencies = [
- "getrandom 0.2.3",
- "lazy_static",
- "proc-macro-hack",
- "tiny-keccak",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,21 +214,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "crossbeam"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
-dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-channel 0.4.4",
- "crossbeam-deque 0.7.3",
- "crossbeam-epoch 0.8.2",
- "crossbeam-queue 0.2.3",
- "crossbeam-utils 0.7.2",
+ "cfg-if",
 ]
 
 [[package]]
@@ -263,22 +223,12 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-channel 0.5.1",
- "crossbeam-deque 0.8.0",
- "crossbeam-epoch 0.9.5",
- "crossbeam-queue 0.3.2",
- "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -287,19 +237,8 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
-dependencies = [
- "crossbeam-epoch 0.8.2",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -308,24 +247,9 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.5",
- "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "lazy_static",
- "maybe-uninit",
- "memoffset 0.5.6",
- "scopeguard",
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -334,22 +258,11 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
+ "cfg-if",
+ "crossbeam-utils",
  "lazy_static",
- "memoffset 0.6.4",
+ "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
-dependencies = [
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
 ]
 
 [[package]]
@@ -358,19 +271,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
 dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils 0.8.5",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 0.1.10",
- "lazy_static",
+ "cfg-if",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -379,15 +281,9 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
-
-[[package]]
-name = "crunchy"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "ctrlc"
@@ -401,15 +297,14 @@ dependencies = [
 
 [[package]]
 name = "cursive"
-version = "0.15.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ceb8704199492858fea2cedf8d9adde0db27755bc4313d771923087f30fbc6"
+checksum = "6593c3409eb794bf22090bec60dda1e19d1def284478bec7e5a92da3cf977c52"
 dependencies = [
  "ahash",
- "cfg-if 0.1.10",
- "crossbeam-channel 0.4.4",
+ "cfg-if",
+ "crossbeam-channel",
  "cursive_core",
- "enumset",
  "lazy_static",
  "libc",
  "log",
@@ -417,61 +312,62 @@ dependencies = [
  "termion",
  "unicode-segmentation",
  "unicode-width",
+ "wasmer_enumset",
 ]
 
 [[package]]
 name = "cursive-tabs"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54395f99e84d46b2d66db5fb763d2e86635e58223a4cf8d1592eb6ad516a37e4"
+checksum = "2fc85c71a80ebf09470b00fb177771b203e2f72df78acdbe6b789b0f2fe4e87d"
 dependencies = [
- "crossbeam 0.7.3",
+ "crossbeam",
  "cursive_core",
  "log",
- "num 0.2.1",
+ "num 0.3.1",
 ]
 
 [[package]]
 name = "cursive_buffered_backend"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ae9c974e17bbd2dc13468d8f8ec8be5d9d885a0300ad2d3756ad4c0676d5a3"
+checksum = "8ff406fcf5a4dd60b55c619704833346dec67af7f2545e4ad96f26777d8bdbcf"
 dependencies = [
  "cursive_core",
- "enumset",
  "log",
  "smallvec",
  "unicode-segmentation",
  "unicode-width",
+ "wasmer_enumset",
 ]
 
 [[package]]
 name = "cursive_core"
-version = "0.1.3"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158e802c91192df6ecd1b9a9f2cbb711fab744ed5ca154f8b47339b83dc5cfb2"
+checksum = "025ac0bcd21ced752d27b70e6aa2285a3513d07b5a0c7f89e71121d20ca1429d"
 dependencies = [
  "ahash",
  "chrono",
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel",
  "enum-map",
- "enumset",
  "lazy_static",
  "libc",
  "log",
  "num 0.3.1",
  "owning_ref",
- "signal-hook",
+ "syn",
  "unicode-segmentation",
  "unicode-width",
+ "wasmer_enumset",
  "xi-unicode",
 ]
 
 [[package]]
 name = "darling"
-version = "0.12.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2c43f534ea4b0b049015d00269734195e6d3f0f6635cb692251aca6f9f8b3c"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -479,23 +375,23 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.12.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e91455b86830a1c21799d94524df0845183fa55bafd9aa137b01c7d1065fa36"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim 0.9.3",
  "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.12.4"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29b5acf0dea37a7f66f7b25d2c5e93fd46f8f6968b1a5d7a3e02e97768afc95a"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote",
@@ -573,27 +469,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enumset"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd795df6708a599abf1ee10eacc72efd052b7a5f70fdf0715e4d5151a6db9c3"
-dependencies = [
- "enumset_derive",
-]
-
-[[package]]
-name = "enumset_derive"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19c52f9ec503c8a68dc04daf71a04b07e690c32ab1a8b68e33897f255269d47"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,7 +523,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "winapi",
@@ -660,7 +535,7 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -703,7 +578,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -714,7 +589,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
@@ -911,7 +786,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -930,25 +805,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
-
-[[package]]
-name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg 1.0.1",
-]
 
 [[package]]
 name = "memoffset"
@@ -995,7 +855,7 @@ checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
 ]
 
@@ -1007,9 +867,9 @@ checksum = "cf1e25ee6b412c2a1e3fcb6a4499a5c1bfe7f43e014bdce9a6b6666e5aa2d187"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "memoffset 0.6.4",
+ "memoffset",
 ]
 
 [[package]]
@@ -1041,6 +901,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b7a8e9be5e039e2ff869df49155f1c06bd01ade2117ec783e56ab0932b67a8f"
 dependencies = [
+ "num-bigint 0.3.2",
  "num-complex 0.3.1",
  "num-integer",
  "num-iter",
@@ -1067,6 +928,17 @@ name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d0a3d5e207573f948a9e5376662aa743a2ea13f7c50a554d7af443a73fbfeba"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -1152,6 +1024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg 1.0.1",
+ "num-bigint 0.3.2",
  "num-integer",
  "num-traits",
 ]
@@ -1303,12 +1176,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -1578,7 +1445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg 1.0.1",
- "crossbeam-deque 0.8.0",
+ "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -1589,9 +1456,9 @@ version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
- "crossbeam-channel 0.5.1",
- "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.5",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
@@ -1602,7 +1469,7 @@ version = "2.0.0"
 dependencies = [
  "anyhow",
  "chrono",
- "crossbeam 0.8.1",
+ "crossbeam",
  "enum-iterator",
  "glob",
  "json",
@@ -1647,7 +1514,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "console",
- "crossbeam 0.8.1",
+ "crossbeam",
  "env_logger",
  "glob",
  "indicatif",
@@ -1686,7 +1553,7 @@ dependencies = [
  "chrono",
  "clap",
  "console",
- "crossbeam 0.8.1",
+ "crossbeam",
  "ctrlc",
  "env_logger",
  "glob",
@@ -1814,7 +1681,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "crossbeam 0.8.1",
+ "crossbeam",
  "cursive",
  "cursive-tabs",
  "cursive_buffered_backend",
@@ -1827,6 +1694,7 @@ dependencies = [
  "rd-hashd-intf",
  "rd-util",
  "tempfile",
+ "term_size",
 ]
 
 [[package]]
@@ -1943,9 +1811,9 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "signal-hook"
-version = "0.1.17"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e31d442c16f047a671b5a71e2161d6e68814012b7f5379d269ebd915fac2729"
+checksum = "470c5a6397076fae0094aaf06a08e6ba6f37acb77d3b1b91ea92b4d6c8650c39"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2011,9 +1879,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "svg"
@@ -2050,7 +1918,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e7de153d0438a648bb71e06e300e54fc641685e96af96d49b843f43172d341c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "core-foundation-sys",
  "doc-comment",
  "libc",
@@ -2077,7 +1945,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "rand 0.8.4",
  "redox_syscall",
@@ -2163,15 +2031,6 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -2272,7 +2131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "265455aab08c55a1ab13f07c8d5e25c7d46900f4484dd7cbd682e77171f93f3c"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
+ "cfg-if",
  "chrono",
  "enum-iterator",
  "getset",
@@ -2300,6 +2159,28 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasmer_enumset"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf088cc1f7d247fd96dff0df46fb1bbb747d8a69ae1ecd71aed55c55e354b2d8"
+dependencies = [
+ "num-traits",
+ "wasmer_enumset_derive",
+]
+
+[[package]]
+name = "wasmer_enumset_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1b32d98e11194200baf6d3f85eb2d6cfe56f6d9af0dd617f90ca48f958a88"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "winapi"
@@ -2343,6 +2224,6 @@ dependencies = [
 
 [[package]]
 name = "xi-unicode"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71b85d8b1b8bfaf4b5c834187554d201a8cd621c2bbfa33efd41a3ecabd48b2"
+checksum = "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a"

--- a/rd-agent/src/main.rs
+++ b/rd-agent/src/main.rs
@@ -998,9 +998,7 @@ impl Config {
         SysReqsReport {
             satisfied: &*ALL_SYSREQS_SET ^ &self.sr_failed.map.keys().copied().collect(),
             missed: self.sr_failed.clone(),
-            kernel_version: sys
-                .kernel_version()
-                .expect("Failed to read kernel version"),
+            kernel_version: sys.kernel_version().expect("Failed to read kernel version"),
             agent_version: FULL_VERSION.to_string(),
             hashd_version,
             nr_cpus: nr_cpus(),

--- a/resctl-demo/Cargo.toml
+++ b/resctl-demo/Cargo.toml
@@ -20,12 +20,13 @@ anyhow = "^1.0"
 chrono = { version = "^0.4", features = ["serde"] }
 clap = "^2.33"
 crossbeam = "^0.8"
-cursive = { version = "^0.15", default-features = false, features = ["termion"] }
-cursive_buffered_backend = "^0.4"
-cursive-tabs = "^0.5"
+cursive = { version = "^0.16", default-features = false, features = ["termion"] }
+cursive_buffered_backend = "^0.5"
+cursive-tabs = "^0.6"
 enum-iterator = "^0.6"
 env_logger = "^0.8"
 lazy_static = "^1.4"
 libc = "^0.2"
 log = "^0.4"
 tempfile = "^3.2"
+term_size = "^0.3"

--- a/resctl-demo/src/doc.rs
+++ b/resctl-demo/src/doc.rs
@@ -444,7 +444,7 @@ fn format_knob_val(knob: &RdKnob, ratio: f64) -> String {
         }
         RdKnob::MemMargin => format_size(ratio * total_memory() as f64),
         RdKnob::Balloon => format_size(ratio * total_memory() as f64),
-        _ => format_pct(ratio) + "%",
+        _ => format4_pct(ratio) + "%",
     };
 
     format!("{:>5}", &v)

--- a/resctl-demo/src/graph.rs
+++ b/resctl-demo/src/graph.rs
@@ -69,13 +69,13 @@ fn refresh_main_graph_title(siv: &mut Cursive) {
 pub fn set_main_graph(siv: &mut Cursive, tag: GraphTag) {
     *GRAPH_MAIN_TAG.lock().unwrap() = tag;
     refresh_main_graph_title(siv);
-    kick_refresh(siv);
+    kick_refresh();
 }
 
 pub fn clear_main_graph(siv: &mut Cursive) {
     *GRAPH_MAIN_TAG.lock().unwrap() = GraphTag::HashdA;
     refresh_main_graph_title(siv);
-    kick_refresh(siv);
+    kick_refresh();
 }
 
 fn graph_tab_id(pos: usize) -> String {

--- a/resctl-demo/src/graph.rs
+++ b/resctl-demo/src/graph.rs
@@ -30,6 +30,7 @@ use rd_util::*;
 const GRAPH_X_ADJ: usize = 20;
 const GRAPH_INTVS: &[u64] = &[1, 5, 15, 30, 60];
 const GRAPH_NR_TABS: usize = 4;
+const GRAPH_TAB_NAMES: &[&'static str] = &["rps/psi", "utilization", "IO", "iocost/psi-some"];
 
 lazy_static::lazy_static! {
     static ref GRAPH_INTV_IDX: Mutex<usize> = Mutex::new(0);
@@ -77,9 +78,13 @@ pub fn clear_main_graph(siv: &mut Cursive) {
     kick_refresh(siv);
 }
 
+fn graph_tab_id(pos: usize) -> String {
+    format!("graph-tab-{}", GRAPH_TAB_NAMES[pos])
+}
+
 fn graph_tab_focus(siv: &mut Cursive, idx: usize) {
-    siv.call_on_name("graph-tabs", |v: &mut TabView<usize>| {
-        let _ = v.set_active_tab(idx);
+    siv.call_on_name("graph-tabs", |v: &mut TabView| {
+        let _ = v.set_active_tab(&graph_tab_id(idx));
     });
 }
 
@@ -882,22 +887,14 @@ pub fn layout_factory(id: GraphSetId) -> Box<dyn View> {
 
     fn graph_tab_title(focus: usize) -> impl View {
         let mut buf = StyledString::new();
-        let mut titles: [String; GRAPH_NR_TABS] = [
-            " rps/psi ".into(),
-            " utilization ".into(),
-            " IO ".into(),
-            " iocost/psi-some ".into(),
-        ];
         let mut styles: [Style; GRAPH_NR_TABS] = [(*COLOR_INACTIVE).into(); GRAPH_NR_TABS];
-
-        titles[focus] = format!("[{}]", titles[focus].trim());
         styles[focus] = (*COLOR_ACTIVE).into();
 
         for i in 0..graph_nr_active_tabs() {
             if i > 0 {
                 buf.append_plain(" | ");
             }
-            buf.append_styled(&titles[i], styles[i]);
+            buf.append_styled(&format!(" {} ", GRAPH_TAB_NAMES[i]), styles[i]);
         }
 
         LinearLayout::vertical()
@@ -923,7 +920,6 @@ pub fn layout_factory(id: GraphSetId) -> Box<dyn View> {
             let mut tabs = TabView::new();
 
             tabs.add_tab(
-                0,
                 LinearLayout::vertical()
                     .child(graph_tab_title(0))
                     .child(
@@ -935,10 +931,10 @@ pub fn layout_factory(id: GraphSetId) -> Box<dyn View> {
                         horiz_or_vert()
                             .child(graph(GraphTag::CpuPsiSome))
                             .child(graph(GraphTag::IoPsiFull)),
-                    ),
+                    )
+                    .with_name(graph_tab_id(0)),
             );
             tabs.add_tab(
-                1,
                 LinearLayout::vertical()
                     .child(graph_tab_title(1))
                     .child(
@@ -950,10 +946,10 @@ pub fn layout_factory(id: GraphSetId) -> Box<dyn View> {
                         horiz_or_vert()
                             .child(graph(GraphTag::CpuUtil))
                             .child(graph(GraphTag::IoUtil)),
-                    ),
+                    )
+                    .with_name(graph_tab_id(1)),
             );
             tabs.add_tab(
-                2,
                 LinearLayout::vertical()
                     .child(graph_tab_title(2))
                     .child(
@@ -965,10 +961,10 @@ pub fn layout_factory(id: GraphSetId) -> Box<dyn View> {
                         horiz_or_vert()
                             .child(graph(GraphTag::ReadLat))
                             .child(graph(GraphTag::WriteLat)),
-                    ),
+                    )
+                    .with_name(graph_tab_id(2)),
             );
             tabs.add_tab(
-                3,
                 LinearLayout::vertical()
                     .child(graph_tab_title(3))
                     .child(
@@ -980,10 +976,11 @@ pub fn layout_factory(id: GraphSetId) -> Box<dyn View> {
                         horiz_or_vert()
                             .child(graph(GraphTag::CpuPsiSome2))
                             .child(graph(GraphTag::IoPsiSome)),
-                    ),
+                    )
+                    .with_name(graph_tab_id(3)),
             );
 
-            let _ = tabs.set_active_tab(*GRAPH_TAB_IDX.lock().unwrap());
+            let _ = tabs.set_active_tab(&graph_tab_id(*GRAPH_TAB_IDX.lock().unwrap()));
 
             Box::new(
                 LinearLayout::vertical()

--- a/resctl-demo/src/journal.rs
+++ b/resctl-demo/src/journal.rs
@@ -10,8 +10,6 @@ use cursive::{CbSink, Cursive};
 use log::info;
 use std::collections::VecDeque;
 use std::sync::Mutex;
-use std::thread::sleep;
-use std::time::{Duration, SystemTime};
 
 use rd_agent_intf::{
     AGENT_SVC_NAME, HASHD_BENCH_SVC_NAME, IOCOST_BENCH_SVC_NAME, OOMD_SVC_NAME,
@@ -23,9 +21,7 @@ use super::doc::{SIDELOAD_NAMES, SYSLOAD_NAMES};
 use super::{get_layout, COLOR_ALERT, COLOR_DFL, COLOR_INACTIVE, SVC_NAMES, UPDATERS};
 
 const JOURNAL_RETENTION: usize = 100;
-const JOURNAL_PERIOD: Duration = Duration::from_millis(100);
 const JOURNAL_FS_RETENTION: usize = 512;
-const JOURNAL_FS_PERIOD: Duration = Duration::from_millis(1000);
 
 lazy_static::lazy_static! {
     static ref FS_CUR: Mutex<String> = Mutex::new(AGENT_SVC_NAME.into());
@@ -104,7 +100,6 @@ impl Updater {
         cb_sink: CbSink,
         units: &[&str],
         retention: usize,
-        period: Duration,
         name: &str,
         panel_name: Option<&str>,
         long_fmt: bool,
@@ -118,19 +113,8 @@ impl Updater {
             tailer: JournalTailer::new(
                 units,
                 retention,
-                Box::new(move |msgs, flush| {
-                    if !flush {
-                        return;
-                    }
+                Box::new(move |msgs, _flush| {
                     Self::update(&cb_sink, msgs, &name, panel_name.as_deref(), long_fmt);
-
-                    if let Ok(latest) =
-                        SystemTime::now().duration_since(msgs.iter().last().unwrap().at)
-                    {
-                        if latest < Duration::from_secs(10) {
-                            sleep(period);
-                        }
-                    }
                 }),
             ),
         }
@@ -213,7 +197,6 @@ pub fn updater_factory(cb_sink: cursive::CbSink, id: JournalViewId) -> Vec<Updat
                     cb_sink.clone(),
                     &top_svcs,
                     JOURNAL_RETENTION,
-                    JOURNAL_PERIOD,
                     "journal-top",
                     None,
                     false,
@@ -222,7 +205,6 @@ pub fn updater_factory(cb_sink: cursive::CbSink, id: JournalViewId) -> Vec<Updat
                     cb_sink.clone(),
                     &bot_svcs,
                     JOURNAL_RETENTION,
-                    JOURNAL_PERIOD,
                     "journal-bot",
                     None,
                     false,
@@ -238,7 +220,6 @@ fn update_fs_journal(siv: &mut Cursive, name: &str) {
         siv.cb_sink().clone(),
         &[name],
         JOURNAL_FS_RETENTION,
-        JOURNAL_FS_PERIOD,
         "journal-fs",
         Some("journal-fs-panel"),
         true,

--- a/resctl-demo/src/main.rs
+++ b/resctl-demo/src/main.rs
@@ -276,11 +276,11 @@ fn refresh_layout(siv: &mut Cursive, layout: &Layout) {
     graph::post_layout(siv);
 }
 
-pub fn kick_refresh(siv: &mut Cursive) {
+pub fn kick_refresh() {
     prog_kick();
     for (_id, upds) in UPDATERS.lock().unwrap().journal.iter() {
         for upd in upds.iter() {
-            upd.refresh(siv);
+            upd.refresh();
         }
     }
 }
@@ -295,7 +295,7 @@ fn refresh_layout_and_kick(siv: &mut Cursive) {
         info!("Resized: {:?} Layout: {:?}", scr, &layout);
         refresh_layout(siv, &layout);
     }
-    kick_refresh(siv);
+    kick_refresh();
 }
 
 fn update_agent_zoomed_view(siv: &mut Cursive) {
@@ -324,7 +324,7 @@ fn update_agent_zoomed_view(siv: &mut Cursive) {
         }
     }
     add_zoomed_layer(siv);
-    kick_refresh(siv);
+    kick_refresh();
 }
 
 fn toggle_zoomed_view(siv: &mut Cursive, target: Option<ZoomedView>) {
@@ -361,7 +361,7 @@ fn toggle_zoomed_view(siv: &mut Cursive, target: Option<ZoomedView>) {
     drop(zv);
 
     add_zoomed_layer(siv);
-    kick_refresh(siv);
+    kick_refresh();
 }
 
 struct ExitGuard {}
@@ -583,13 +583,13 @@ fn main() {
     siv.add_global_callback('l', |siv| {
         toggle_zoomed_view(siv, Some(ZoomedView::Journals))
     });
-    siv.add_global_callback('t', |siv| {
+    siv.add_global_callback('t', |_siv| {
         graph::graph_intv_next();
-        kick_refresh(siv);
+        kick_refresh();
     });
-    siv.add_global_callback('T', |siv| {
+    siv.add_global_callback('T', |_siv| {
         graph::graph_intv_prev();
-        kick_refresh(siv);
+        kick_refresh();
     });
 
     siv.set_global_callback(event::Event::WindowResize, move |siv| {

--- a/resctl-demo/src/main.rs
+++ b/resctl-demo/src/main.rs
@@ -82,7 +82,7 @@ lazy_static::lazy_static! {
     static ref ZOOMED_VIEW: Mutex<Vec<ZoomedView>> = Mutex::new(Vec::new());
     pub static ref STYLE_ALERT: Style = Style {
         effects: Effect::Bold | Effect::Reverse,
-        color: Some((*COLOR_ALERT).into()),
+        color: (*COLOR_ALERT).into(),
     };
     pub static ref SVC_NAMES: Vec<String> = {
         // trigger DOCS init so that SIDELOAD/SYSLOAD_NAMES get initialized
@@ -287,7 +287,8 @@ pub fn kick_refresh(siv: &mut Cursive) {
 
 fn refresh_layout_and_kick(siv: &mut Cursive) {
     let mut layout = get_layout();
-    let scr = siv.screen_size();
+    let (x, y) = term_size::dimensions().unwrap_or((80, 24));
+    let scr = cursive::XY { x, y };
     if scr != layout.screen {
         *LAYOUT.lock().unwrap() = Layout::new(scr);
         layout = get_layout();
@@ -530,15 +531,7 @@ fn main() {
     info!("TEMP_DIR: {:?}", TEMP_DIR.path());
     touch_units();
 
-    // Use the termion backend so that resctl-demo can be built without
-    // external dependencies. The buffered backend wrapping is necessary to
-    // avoid flickering, see https://github.com/gyscos/cursive/issues/525.
-    let mut siv = Cursive::new(|| {
-        let termion_backend = cursive::backends::termion::Backend::init().unwrap();
-        Box::new(cursive_buffered_backend::BufferedBackend::new(
-            termion_backend,
-        ))
-    });
+    let mut siv = Cursive::default();
     set_cursive_theme(&mut siv);
 
     let _exit_guard = ExitGuard {};
@@ -575,7 +568,6 @@ fn main() {
     });
     siv.add_global_callback(event::Event::CtrlChar('l'), |siv| {
         siv.clear();
-        siv.refresh();
     });
     siv.add_global_callback(event::Event::Key(event::Key::Esc), |siv| {
         AGENT_ZV_REQ.store(false, Ordering::Relaxed);
@@ -620,6 +612,14 @@ fn main() {
     refresh_layout_and_kick(&mut siv);
     update_agent_zoomed_view(&mut siv);
 
-    // Run the event loop
-    siv.run();
+    // Run the event loop. Use the termion backend so that resctl-demo can
+    // be built without external dependencies. The buffered backend wrapping
+    // is necessary to avoid flickering, see
+    // https://github.com/gyscos/cursive/issues/525.
+    siv.run_with(|| {
+        let termion_backend = cursive::backends::termion::Backend::init().unwrap();
+        Box::new(cursive_buffered_backend::BufferedBackend::new(
+            termion_backend,
+        ))
+    })
 }


### PR DESCRIPTION
Update cursive to 0.16 and use the new features:

* Replace the custom indexing and iterated updates for multiple elements with the same name with `call_on_all_named()`.
* Implement incremental log view update.

While at it, fix slider bar formatting breakage.