### PR TITLE
bench: improve shadow inode protection handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,6 +1591,7 @@ dependencies = [
  "serde_json",
  "statistical",
  "statrs",
+ "sysinfo",
  "tar",
  "tempfile",
  "term_size",

--- a/rd-agent/src/main.rs
+++ b/rd-agent/src/main.rs
@@ -12,7 +12,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::sleep;
 use std::time::Duration;
-use sysinfo::{self, ProcessExt, SystemExt};
+use sysinfo::{ProcessExt, SystemExt};
 
 mod bandit;
 mod bench;

--- a/resctl-bench/Cargo.toml
+++ b/resctl-bench/Cargo.toml
@@ -34,6 +34,7 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
 statistical = "^1.0"
 statrs = "^0.15"
+sysinfo = "^0.19"
 tar = "^0.4"
 tempfile = "^3.2"
 term_size = "^0.3"

--- a/resctl-bench/doc/shadow-inode.md
+++ b/resctl-bench/doc/shadow-inode.md
@@ -24,12 +24,19 @@ can make the kernel lose this information prematurely:
   reality, is under extreme memory pressure, completely voiding memory
   protection through memory.low and memor.min.
 
-There is a proposed solution:
+There is a pending solution which is scheduled to be merged for v5.15:
 
   https://lore.kernel.org/linux-fsdevel/20210614211904.14420-4-hannes@cmpxchg.org/
 
-but it needs a bit more work to be merged upstream. The following git branch
-contains v5.13-rc7 + the proposed patches which can be used in the meantime:
+The following git branch contains v5.14-rc6 + the proposed patches which can
+be used in the meantime:
 
-  https://git.kernel.org/pub/scm/linux/kernel/git/tj/misc.git resctl-demo-v5.13-rc7
+  https://git.kernel.org/pub/scm/linux/kernel/git/tj/misc.git resctl-demo-v5.14-rc6
 
+Note that the above branch contains a patch which tags the kernel as having
+shadow inode protection. Without the tagging, on kernels < v5.15,
+resctl-bench doesn't have a quick and reliable way to tell whether shadow
+inodes are protected and tries to test inode protection with a benchmark
+which can take several minutes. Unfortunately, the test isn't completely
+reliable and may occasionally produce incorrect results. It is recommended
+to upgrade to the kernel >= v5.15 or apply the tagging patch.

--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -4,7 +4,7 @@ use super::iocost_qos::{
 };
 use super::protection::MemHog;
 use super::*;
-use statrs::distribution::{Normal, ContinuousCDF};
+use statrs::distribution::{ContinuousCDF, Normal};
 use std::cell::RefCell;
 use std::cmp::{Ordering, PartialOrd};
 use std::collections::{BTreeMap, BTreeSet};

--- a/resctl-bench/src/bench/iocost_tune/merge.rs
+++ b/resctl-bench/src/bench/iocost_tune/merge.rs
@@ -1,6 +1,6 @@
 use super::super::*;
 use super::{DataSel, DataSeries, IoCostTuneBench, IoCostTuneRecord, IoCostTuneResult};
-use statrs::distribution::{Normal, ContinuousCDF};
+use statrs::distribution::{ContinuousCDF, Normal};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 fn model_to_array(model: &IoCostModelParams) -> [f64; 6] {

--- a/resctl-bench/src/run.rs
+++ b/resctl-bench/src/run.rs
@@ -643,7 +643,7 @@ impl<'a, 'b> RunCtx<'a, 'b> {
         let started_at = unix_now() as i64;
         if let Err(e) = self.wait_cond(
             |af, progress| {
-                progress.set_status("Waiting rd-agent to start");
+                progress.set_status("Waiting for rd-agent to start");
                 let rep = &af.report.data;
                 rep.timestamp.timestamp() > started_at && rep.state == RunnerState::Running
             },


### PR DESCRIPTION
The test takes too long and isn't completely reliable. Work around by:

* Assume fbks and kernels >= v5.15 are protected.

* Add a pseudo module param marker in the resctl-demo kernel so that it can
  be tested quickly.