### PR TITLE
Scale rps with memprof

### DIFF
--- a/resctl-bench/src/base.rs
+++ b/resctl-bench/src/base.rs
@@ -300,6 +300,7 @@ impl<'a> Base<'a> {
         // rd-hashd benchmark.
         HashdFakeCpuBench {
             size: rd_hashd_intf::Args::DFL_SIZE_MULT * total_memory() as u64,
+            rps_max: 2000,
             grain_factor: 2.0,
             ..HashdFakeCpuBench::base(&rctx)
         }

--- a/resctl-bench/src/bench.rs
+++ b/resctl-bench/src/bench.rs
@@ -49,9 +49,10 @@ lazy_static::lazy_static! {
     };
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct HashdFakeCpuBench {
     pub size: u64,
-    pub log_bps: Option<u64>,
+    pub log_bps: u64,
     pub hash_size: usize,
     pub chunk_pages: usize,
     pub rps_max: u32,
@@ -65,7 +66,7 @@ impl HashdFakeCpuBench {
 
         Self {
             size: dfl_args.size,
-            log_bps: None,
+            log_bps: dfl_params.log_bps,
             hash_size: dfl_params.file_size_mean,
             chunk_pages: dfl_params.chunk_pages,
             rps_max: RunCtx::BENCH_FAKE_CPU_RPS_MAX,
@@ -75,7 +76,7 @@ impl HashdFakeCpuBench {
 
     pub fn start(&self, rctx: &mut RunCtx) -> Result<()> {
         rctx.start_hashd_bench(
-            self.log_bps,
+            Some(self.log_bps),
             // We should specify all the total_memory() dependent values in
             // rd_hashd_intf::Args so that the behavior stays the same for
             // the same mem_profile.

--- a/resctl-bench/src/bench.rs
+++ b/resctl-bench/src/bench.rs
@@ -61,15 +61,22 @@ pub struct HashdFakeCpuBench {
 
 impl HashdFakeCpuBench {
     pub fn base(rctx: &RunCtx) -> Self {
-        let dfl_args = rd_hashd_intf::Args::with_mem_size(rctx.mem_info().share);
+        let mem_share = rctx.mem_info().share;
+        let dfl_args = rd_hashd_intf::Args::with_mem_size(mem_share);
         let dfl_params = rd_hashd_intf::Params::default();
+
+        // Scale max RPS to memory share so that larger memory profile also
+        // implies stronger CPUs. RPS_MAX_PER_GB is picked so that 16G
+        // memory profile with 12G mem_share ends up with ~2000 RPS.
+        const RPS_MAX_PER_GB: f64 = 166.67;
+        let rps_max = (mem_share as f64 / (1 << 30) as f64 * RPS_MAX_PER_GB).round() as u32;
 
         Self {
             size: dfl_args.size,
             log_bps: dfl_params.log_bps,
             hash_size: dfl_params.file_size_mean,
             chunk_pages: dfl_params.chunk_pages,
-            rps_max: RunCtx::BENCH_FAKE_CPU_RPS_MAX,
+            rps_max,
             grain_factor: 1.0,
         }
     }

--- a/resctl-bench/src/bench/iocost_qos.rs
+++ b/resctl-bench/src/bench/iocost_qos.rs
@@ -59,7 +59,7 @@ impl Bench for IoCostQoSBench {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IoCostQoSRecordRun {
     pub period: (u64, u64),
     pub ovr: IoCostQoSOvr,

--- a/resctl-bench/src/run.rs
+++ b/resctl-bench/src/run.rs
@@ -913,8 +913,6 @@ impl<'a, 'b> RunCtx<'a, 'b> {
         Ok(())
     }
 
-    pub const BENCH_FAKE_CPU_RPS_MAX: u32 = 2000;
-
     pub fn start_hashd_bench(
         &mut self,
         log_bps: Option<u64>,


### PR DESCRIPTION
Fake cpu load hashd benchmarks are used to evaluate storage performance in
isolation. Let's scale the max RPS along with mem_share so that larger
memory profile means tougher IO workload so that users have the ability to
scale up the benchmark if necessary.

The scaling factor is set up so that the max RPS remains at 2000 when the
default 16G memory profile.
