### PR TITLE
Iocost tune solutions

### DIFF
--- a/resctl-bench/doc/iocost-tune.md
+++ b/resctl-bench/doc/iocost-tune.md
@@ -89,32 +89,22 @@ write latencies.
 
 #### `bandwidth`
 
-This targets the minimum vrate which renders the maximum `MOF. Going higher
-deteriorates control quality without increasing supportable memory
-footprint.
-
-While using `rd-hashd`'s behavior as the standard is somewhat arbitrary, we
-have to set the bar somewhere and `rd-hashd` is tuned to behave similar to a
-popular facebook production workload under memory and IO pressures. While
-it's arguable whether this is the exact point we wanna settle on, it's good
-at steering away from configurations which are clearly out of bounds.
+This targets the maximum vrate at which `rd-hashd` can be isolated
+sufficiently - isol-01 >= 90%. Sizing memory footprint may be challenging
+with this solution - a workload sized for saturation may be too big for
+isolation.
 
 #### `isolated-bandwidth` 
 
-This targets the minimum vrate which renders the maximum aMOF. Going higher
-deteriorates control quality without increasing memory footprint which can
-be protected.
-
-In the unlikely case that the vrate at the aMOF inflection point is lower
-than the `isolation` solution, `isolated-bandwidth` uses the `isolation`
-solution instead, so `isolated-bandwidth` is guaranteed to be throttled
-equally to or less than `isolation`.
+This targets the maximum vrate which provides the lowest latency impact,
+clamped between the `isolation` and `bandwidth` solutions. This is the vrate
+below which the isolation quality doesn't improve.
 
 #### `isolation`
 
-This targets the maximum vrate which renders the minimum aMOF-delta. This is
-the point where a workload sized for saturation is most likely to be
-isolatable.
+This targets the maximum vrate which renders the minimum aMOF-delta. Sizing
+for isolation is the easiest with this solution - a workload sized for
+saturation is as close to be isolable as possible on the device.
 
 #### `rlat-99-q[1-4]`
 

--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -382,6 +382,7 @@ enum QoSTarget {
     VrateRange((f64, f64), (Option<String>, Option<String>)),
     MOFMax,
     AMOFMax,
+    AMOFMaxVrate,
     IsolatedBandwidth,
     Isolation,
     LatRange(DataSel, (f64, f64)),
@@ -415,8 +416,9 @@ impl std::fmt::Display for QoSTarget {
             }
             Self::MOFMax => write!(f, "MOF=max").unwrap(),
             Self::AMOFMax => write!(f, "aMOF=max").unwrap(),
+            Self::AMOFMaxVrate => write!(f, "aMOF=max-vrate").unwrap(),
             Self::IsolatedBandwidth => {
-                write!(f, "isolated-bandwidth (max(isolation, aMOF=MAX))").unwrap()
+                write!(f, "isolated-bandwidth (max(isolation, aMOF=max))").unwrap()
             }
             Self::Isolation => write!(f, "isolation (aMOF-delta=min)").unwrap(),
             Self::LatRange(sel, (low, high)) => match sel {
@@ -511,16 +513,15 @@ impl QoSTarget {
             k => {
                 let sel = DataSel::parse(k)?;
                 match &sel {
-                    DataSel::MOF | DataSel::AMOF => {
-                        if v != "max" {
-                            bail!("Invalid {:?} value {:?}", &sel, &v);
-                        }
-                        if sel == DataSel::MOF {
-                            Ok(Self::MOFMax)
-                        } else {
-                            Ok(Self::AMOFMax)
-                        }
-                    }
+                    DataSel::MOF => match v.as_str() {
+                        "max" => Ok(Self::MOFMax),
+                        v => bail!("Invalid {:?} value {:?}", &sel, &v),
+                    },
+                    DataSel::AMOF => match v.as_str() {
+                        "max" => Ok(Self::AMOFMax),
+                        "max-vrate" => Ok(Self::AMOFMaxVrate),
+                        v => bail!("Invalid {:?} value {:?}", &sel, &v),
+                    },
                     DataSel::RLat(_, time_pct) | DataSel::WLat(_, time_pct) => {
                         if time_pct != "mean" {
                             bail!("Latency range target should have \"mean\" for time percentile");
@@ -562,6 +563,7 @@ impl QoSTarget {
             }
             Self::MOFMax => vec![DataSel::MOF, DataSel::LatImp],
             Self::AMOFMax => vec![DataSel::AMOF, DataSel::LatImp],
+            Self::AMOFMaxVrate => vec![DataSel::AMOF],
             Self::IsolatedBandwidth => vec![
                 DataSel::MOF,
                 DataSel::AMOF,
@@ -730,6 +732,13 @@ impl QoSTarget {
             ))
         };
 
+        let solve_max_vrate = |sel| -> Result<Option<f64>> {
+            Ok(ds(sel)?
+                .lines
+                .clamped(scale_min, scale_max)
+                .map(|dl| dl.range.1))
+        };
+
         let solve_isolation = || -> Result<Option<f64>> {
             let amof_delta_ds = ds(&DataSel::AMOFDelta)?;
             Ok(solve_mof_max(&DataSel::MOF, Some(&DataSel::LatImp))?
@@ -761,12 +770,22 @@ impl QoSTarget {
                     *scale_max,
                 ))
             }
+
+            // Min vrate still at max MOF. If MOF is flat, max vrate at min
+            // LatImp.
             Self::MOFMax => {
                 solve_mof_max(&DataSel::MOF, Some(&DataSel::LatImp))?.map(params_at_vrate)
             }
+
+            // Min vrate still at max aMOF. If MOF is flat, max vrate at min
+            // LatImp.
             Self::AMOFMax => {
                 solve_mof_max(&DataSel::AMOF, Some(&DataSel::LatImp))?.map(params_at_vrate)
             }
+
+            // Rightmost vrate with valid aMOF.
+            Self::AMOFMaxVrate => solve_max_vrate(&DataSel::AMOF)?.map(params_at_vrate),
+
             Self::IsolatedBandwidth => {
                 // Isolation if it has the maximum aMOF; otherwise, the
                 // lowest vrate which maps to max aMOF. Note that we don't
@@ -782,7 +801,9 @@ impl QoSTarget {
                 }
                 .map(params_at_vrate)
             }
+
             Self::Isolation => solve_isolation()?.map(params_at_vrate),
+
             Self::LatRange(sel, lat_rel_range) => {
                 if let Some((lat_target, vrate_range)) =
                     Self::solve_lat_range(ds(&sel)?, *lat_rel_range, (scale_min, scale_max))
@@ -926,7 +947,7 @@ impl Bench for IoCostTuneBench {
             };
 
             push_props(&[("name", "naive")]);
-            push_props(&[("name", "bandwidth"), ("mof", "max")]);
+            push_props(&[("name", "bandwidth"), ("amof", "max-vrate")]);
             push_props(&[("name", "isolated-bandwidth"), ("isolated-bandwidth", "")]);
             push_props(&[("name", "isolation"), ("isolation", "")]);
             push_props(&[("name", "rlat-99-q1"), ("rlat-99", "q1")]);

--- a/resctl-bench/src/study.rs
+++ b/resctl-bench/src/study.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 use anyhow::{bail, Result};
+use log::trace;
 use num_traits::cast::AsPrimitive;
 use quantiles::ckms::CKMS;
 use std::cell::RefCell;
@@ -284,7 +285,7 @@ impl<'a> Studies<'a> {
 
         let mut last_at_ms = None;
         let mut cnt = 0;
-        for (rep, _) in run.report_iter(period) {
+        for (rep, at) in run.report_iter(period) {
             cnt += 1;
             match rep {
                 Ok(rep) => {
@@ -308,7 +309,10 @@ impl<'a> Studies<'a> {
                     nr_reps += 1;
                     cnt = 0;
                 }
-                Err(_) => nr_missed += 1,
+                Err(e) => {
+                    trace!("failed to load {} ({:#})", at, &e);
+                    nr_missed += 1;
+                }
             }
             if prog_exiting() {
                 bail!("Program exiting");


### PR DESCRIPTION
iocost-tune was using a[MOF]=max points as the upper limits when calculating solutions with the rationale that going higher doesn't add to bw increase for hashd while potentially worsening control quality. However, this is only true when the system is running only one instance of hashd. As such, all it says about is the ratio between hashd's latency requirement and the device's average completion latency. If the latency requirement changes, more instances of hashd run on the machine, or something else shares the machine, the a[MOF]=max point doesn't really give any indication on where "useful" bandwidth ends.

Let's drop it as upper bound and update the solution rules as follows:

* bandwidth: The maximum vrate at which hashd can still be protected.
* isolated-bandwidth: The maximum vrate where latency impact can be minimized. Clamped between bandwidth and isolation solutions.
* isolation: The maximum vrate where aMOF-delta can be minimized (ie. the easiest to size for isolation).
