### PR TITLE
bench: ignore bench updates in study mode

### DIFF
--- a/resctl-bench/src/base.rs
+++ b/resctl-bench/src/base.rs
@@ -218,9 +218,12 @@ impl<'a> Base<'a> {
 
     fn apply_bench_knobs(&mut self, knobs: BenchKnobs, commit: bool) -> Result<()> {
         self.bench_knobs = knobs;
-        self.save_bench_knobs(&self.bench_knobs_path)?;
-        if commit {
-            self.save_bench_knobs(&self.demo_bench_knobs_path)?;
+        // bench_knobs_path is not set in study mode. Ignore.
+        if self.bench_knobs_path.len() > 0 {
+            self.save_bench_knobs(&self.bench_knobs_path)?;
+            if commit {
+                self.save_bench_knobs(&self.demo_bench_knobs_path)?;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
In study mode, no benchmark is actually being run and the bench file doesn't
need to be and can't be updated (the path is not initialized). Silently
bypass apply_bench_knobs() if bench_knobs path is not set to avoid causing
spurious failures in study mode.