### PR TITLE
bench: error out if no job spec was specified for subcommands which n…

### DIFF
--- a/resctl-bench-intf/src/args.rs
+++ b/resctl-bench-intf/src/args.rs
@@ -344,6 +344,10 @@ impl Args {
                     self.job_specs = job_specs;
                     updated = true;
                 }
+                if self.job_specs.len() == 0 {
+                    error!("{:?} requires job specs", &mode);
+                    exit(1);
+                }
             }
             Err(e) => {
                 error!("{}", &e);


### PR DESCRIPTION
…eed them

Before, resctl-bench would "succeed" without doing anyting, which can be
confusing.