### PR TITLE
Fix default branch name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ possible.
 ## Pull Requests
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `main`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Ensure the test suite passes.

--- a/resctl-bench-intf/src/args.rs
+++ b/resctl-bench-intf/src/args.rs
@@ -13,7 +13,7 @@ use rd_agent_intf;
 use rd_util::*;
 
 pub const GITHUB_DOC_LINK: &'static str =
-    "https://github.com/facebookexperimental/resctl-demo/tree/master/resctl-bench/doc";
+    "https://github.com/facebookexperimental/resctl-demo/tree/main/resctl-bench/doc";
 
 lazy_static::lazy_static! {
     static ref TOP_ARGS_STR: String = {

--- a/resctl-bench/README.md
+++ b/resctl-bench/README.md
@@ -76,8 +76,8 @@ maps to:
 
 Here are the example outputs:
 
-* Summary:  https://github.com/facebookexperimental/resctl-demo/blob/master/resctl-bench/examples/prot-iocost-off-on-summary.txt
-* Format: https://github.com/facebookexperimental/resctl-demo/blob/master/resctl-bench/examples/prot-iocost-off-on-format.txt
+* Summary:  https://github.com/facebookexperimental/resctl-demo/blob/main/resctl-bench/examples/prot-iocost-off-on-summary.txt
+* Format: https://github.com/facebookexperimental/resctl-demo/blob/main/resctl-bench/examples/prot-iocost-off-on-format.txt
 
 Let's look at the result of the first benchmark - `hashd-params`.
 
@@ -148,7 +148,7 @@ main workload's RPS halved while the system was experiencing memory
 shortage. For more information on the output format:
 
 * `$ resctl-bench doc protection`
-* https://github.com/facebookexperimental/resctl-demo/blob/master/resctl-bench/doc/protection.md
+* https://github.com/facebookexperimental/resctl-demo/blob/main/resctl-bench/doc/protection.md
 
 So, we now know that without `iocost`, the protection isn't great. The next
 `iocost-params` benchmark determines the parameters so that we can enable
@@ -204,4 +204,4 @@ that exercise every layer of the tall stack realistically is easy and
 reliable with `resctl-bench`. For more information, explore the doc pages:
 
 * `$ resctl-bench doc --help`
-* https://github.com/facebookexperimental/resctl-demo/tree/master/resctl-bench/doc
+* https://github.com/facebookexperimental/resctl-demo/tree/main/resctl-bench/doc


### PR DESCRIPTION
The default branch name was not updated in some places. Fix it.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>