### PR TITLE
New workflow to deploy the lambda function

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Cargo build
-        run: cargo build
+        run: cargo build --all-features
 
       - name: Cargo test
         run: cargo test

--- a/.github/workflows/lambda.yaml
+++ b/.github/workflows/lambda.yaml
@@ -37,7 +37,7 @@ jobs:
           CC_x86_64_unknown_linux_musl: musl-gcc
         run: >
           cd ${GITHUB_WORKSPACE}/resctl-demo &&
-          cargo build --release --all-features --target x86_64-unknown-linux-musl
+          cargo build --release --features lambda --target x86_64-unknown-linux-musl
 
       - name: Package for AWS lambda
         run: >

--- a/.github/workflows/lambda.yaml
+++ b/.github/workflows/lambda.yaml
@@ -10,6 +10,9 @@ jobs:
   build-upload-lambda-function:
     name: Build and deploy
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -52,11 +55,9 @@ jobs:
             bootstrap
 
       - name: Prepare AWS environment
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          role-to-assume: IoCostLambdaManager
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 1200
           aws-region: ${{ secrets.AWS_REGION }}
 

--- a/.github/workflows/lambda.yaml
+++ b/.github/workflows/lambda.yaml
@@ -1,0 +1,65 @@
+name: Build and deploy lambda function
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  build-upload-lambda-function:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Checkout resctl-demo repository
+        uses: actions/checkout@v2
+        with:
+          path: 'resctl-demo'
+
+      - name: Install musl toolchain
+        run: sudo apt install -y musl-tools
+
+      - name: Add musl target
+        run: rustup target add x86_64-unknown-linux-musl
+
+      - name: Build with all features
+        env:
+          CC_x86_64_unknown_linux_musl: musl-gcc
+        run: >
+          cd ${GITHUB_WORKSPACE}/resctl-demo &&
+          cargo build --release --all-features --target x86_64-unknown-linux-musl
+
+      - name: Package for AWS lambda
+        run: >
+          find ;
+          cp resctl-demo/target/x86_64-unknown-linux-musl/release/resctl-bench ./bootstrap &&
+          zip -j resctl-bench-lambda.zip bootstrap
+
+      - name: Publish artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: resctl-bench-lambda
+          retention-days: 14
+          if-no-files-found: error
+          path: |
+            bootstrap
+
+      - name: Prepare AWS environment
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: IoCostLambdaManager
+          role-duration-seconds: 1200
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Update lambda function
+        run: >
+          aws lambda update-function-code --function-name "iocost-submit" --zip-file fileb://resctl-bench-lambda.zip


### PR DESCRIPTION
Build the lambda function, package it as expected by AWS lambda, then update it on AWS.

For now this is only triggered manually, so that the update can be performed only when it makes sense to the developers. In the future we can make a release being tagged trigger this workflow.