### PR TITLE
Add initial PackIt config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 **/*.rs.bk
+/rust-resctl-demo-*.tar.gz
+/rust-resctl-demo-*.src.rpm
+/rust-resctl-demo.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,36 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rust-resctl-demo.spec
+files_to_sync:
+  - rust-resctl-demo.spec
+  - .packit.yaml
+
+upstream_package_name: rust-resctl-demo
+downstream_package_name: resctl-demo
+actions:
+  # Fetch the specfile from Rawhide and drop any patches
+  # Also drop the vendored tarball for now
+  post-upstream-clone: "bash -c \"curl -s https://src.fedoraproject.org/rpms/rust-resctl-demo/raw/main/f/rust-resctl-demo.spec | sed -e '/^Patch[0-9]/d' -e '/Source1/d' > rust-resctl-demo.spec\""
+
+jobs:
+- job: copr_build
+  trigger: commit
+  metadata:
+    targets:
+      - fedora-all-aarch64
+      - fedora-all-armhfp
+      - fedora-all-i386
+      - fedora-all-ppc64le
+      - fedora-all-s390x
+      - fedora-all-x86_64
+- job: copr_build
+  trigger: pull_request
+  metadata:
+    targets:
+      - fedora-all-aarch64
+      - fedora-all-armhfp
+      - fedora-all-i386
+      - fedora-all-ppc64le
+      - fedora-all-s390x
+      - fedora-all-x86_64


### PR DESCRIPTION
This will gives us on-demand Fedora builds. Leaving out EPEL for now as that requires a vendoring and I'm not quite sure how to handle it yet.