### PR TITLE
util: relax version requirement of the vergen crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,9 +2829,9 @@ dependencies = [
 
 [[package]]
 name = "simplelog"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d0fe306a0ced1c88a58042dc22fc2ddd000982c26d75f6aa09a394547c41e0"
+checksum = "c1348164456f72ca0116e4538bdaabb0ddb622c7d9f16387c725af3e96d6001c"
 dependencies = [
  "chrono",
  "log",
@@ -3376,9 +3376,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "vergen"
-version = "5.1.15"
+version = "5.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265455aab08c55a1ab13f07c8d5e25c7d46900f4484dd7cbd682e77171f93f3c"
+checksum = "6cf88d94e969e7956d924ba70741316796177fa0c79a2c9f4ab04998d96e966e"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/rd-util/Cargo.toml
+++ b/rd-util/Cargo.toml
@@ -38,4 +38,4 @@ sysinfo = "^0.19"
 
 [build-dependencies]
 anyhow = "^1.0"
-vergen = "^5.1.14"
+vergen = "^5.1"


### PR DESCRIPTION
This fixes build on machine w/ newer libgit2.