### PR TITLE
bench: add upload subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,6 +1543,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "minreq"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c785bc6027fd359756e538541c8624012ba3776d3d3fe123885643092ed4132"
+dependencies = [
+ "lazy_static",
+ "log",
+ "rustls 0.20.4",
+ "serde",
+ "serde_json",
+ "webpki 0.22.0",
+ "webpki-roots",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,6 +2475,7 @@ dependencies = [
  "linreg",
  "log",
  "md5",
+ "minreq",
  "num-traits",
  "octocrab",
  "plotlib",

--- a/rd-util/src/lib.rs
+++ b/rd-util/src/lib.rs
@@ -5,6 +5,7 @@ use crossbeam::channel::Sender;
 use glob::glob;
 use log::{error, info, warn};
 use scan_fmt::scan_fmt;
+use serde::{Deserialize, Serialize};
 use simplelog as sl;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -920,6 +921,21 @@ pub fn wait_prog_state(dur: Duration) -> ProgState {
             return ProgState::Running;
         }
     }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct LambdaRequest {
+    pub data: String,
+    pub email: Option<String>,
+    pub github: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LambdaResponse {
+    pub issue: Option<String>,
+    pub error_type: Option<String>,
+    pub error_message: Option<String>,
 }
 
 #[cfg(test)]

--- a/resctl-bench/Cargo.toml
+++ b/resctl-bench/Cargo.toml
@@ -10,7 +10,7 @@ description = "Whole system resource control benchmarks with realistic scenarios
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-lambda = ["resctl-bench-intf/lambda", "aws-config", "aws-sdk-s3", "aws-sdk-ssm", "base64", "octocrab", "lambda_runtime", "md5", "tokio"]
+lambda = ["resctl-bench-intf/lambda", "aws-config", "aws-sdk-s3", "aws-sdk-ssm", "octocrab", "lambda_runtime", "md5", "tokio"]
 
 [dependencies]
 rd-util = { path = "../rd-util", version = "^2.1" }
@@ -22,13 +22,13 @@ resctl-bench-intf = { path = "../resctl-bench-intf", version = "^2.1" }
 aws-config = { version = "0.6", optional = true, features = ["rustls", "rt-tokio"], default-features = false  }
 aws-sdk-s3 = { version = "0.6", optional = true, features = ["rustls", "rt-tokio"], default-features = false  }
 aws-sdk-ssm = { version = "0.6", optional = true, features = ["rustls", "rt-tokio"], default-features = false  }
-base64 = { version = "0.13", optional = true  }
 lambda_runtime = { version = "0.4", optional = true  }
 md5 = { version = "0.7", optional = true  }
 octocrab = { version = "0.15", optional = true, features = ["rustls"], default-features = false }
 tokio = { version = "1.6", optional = true }
 
 anyhow = "^1.0"
+base64 = "^0.13"
 chrono = "^0.4"
 console = "^0.15"
 env_logger = "^0.9"
@@ -38,6 +38,7 @@ libc = "^0.2"
 libflate = "^1.1"
 linreg = "^0.2"
 log = "^0.4"
+minreq = { version= "^2.6", features = ["https-rustls", "json-using-serde"] }
 num-traits = "^0.2"
 plotlib = "^0.5"
 quantiles = "^0.7"

--- a/resctl-bench/src/lambda.rs
+++ b/resctl-bench/src/lambda.rs
@@ -1,11 +1,16 @@
 // Copyright (c) Facebook, Inc. and its affiliates.
 // Copyright (c) Collabora Ltd.
-use anyhow::{anyhow, Error, Result};
+use anyhow::{anyhow, Context, Error, Result};
+use aws_sdk_s3::{
+    error::{GetObjectError, GetObjectErrorKind},
+    SdkError,
+};
 use log::error;
-use serde::{Deserialize, Serialize};
-use std::io::Write;
+use std::io::{Cursor, Read, Write};
 use std::os::unix::process::CommandExt;
 use std::path::Path;
+
+use rd_util::{LambdaRequest as Request, LambdaResponse as Response};
 
 use crate::job::{FormatOpts, JobCtxs};
 
@@ -36,42 +41,50 @@ pub async fn run() -> Result<()> {
     let handler = |request: Request, _| async move {
         let helper = LambdaHelper::new().await;
 
+        // Unpack the base64 encoded gz-compressed file. This is safe because Lambda has a hard
+        // limit on the size of the requests (6MB at the moment).
+        let data = base64::decode(&request.data)?;
+
         // Loading the results and formatting sysinfo and summary serve as validation
         // that the uploaded file is a properly formated benchmark result.
-        let jctxs = helper.load_results(&request.data).await?;
+        let jctxs = helper.load_results(&data).await?;
 
         let sysinfo = helper.format_sysinfo(&jctxs)?;
         let summary = helper.format_summary(&jctxs)?;
 
-        // Valid! Let's upload to S3.
-        let s3_url = helper
-            .save_to_s3(&helper.object_name_from_hash(&request.data))
-            .await?;
+        // Valid! Let's check we do not have a duplicate and upload to S3.
+        let object_name = helper.object_name_from_hash(&data)?;
+
+        if helper.s3_object_exists(&object_name).await? {
+            return Ok(Response {
+                issue: None,
+                error_type: Some(format!("Custom")),
+                error_message: Some(format!("This file has already been submitted.")),
+            });
+        }
+
+        let s3_url = helper.save_to_s3(&object_name).await?;
 
         // Now we just need to tell the world.
+        let identification = helper.format_submitter_info(&request);
         let issue_url = helper
-            .create_github_issue(&sysinfo, &format!("{}\n\n```\n{}\n```", s3_url, summary))
+            .create_github_issue(
+                &sysinfo,
+                &format!("{}\n\n{}```\n{}\n```", s3_url, identification, summary),
+            )
             .await?;
 
-        Ok::<_, Error>(Response { issue: issue_url })
+        Ok::<_, Error>(Response {
+            issue: Some(issue_url),
+            error_type: None,
+            error_message: None,
+        })
     };
 
     lambda_runtime::run(lambda_runtime::handler_fn(handler))
         .await
         .map_err(|e| anyhow!(e))?;
     Ok(())
-}
-
-#[cfg(feature = "lambda")]
-#[derive(Deserialize, Serialize)]
-pub struct Request {
-    pub data: String,
-}
-
-#[cfg(feature = "lambda")]
-#[derive(Deserialize, Serialize)]
-pub struct Response {
-    pub issue: String,
 }
 
 pub struct LambdaHelper {
@@ -89,16 +102,35 @@ impl LambdaHelper {
         }
     }
 
-    pub async fn load_results(&self, data: &str) -> Result<JobCtxs> {
-        // Unpack the base64 encoded gz-compressed file. This is safe because Lambda has a hard
-        // limit on the size of the requests (6MB at the moment).
-        let data = base64::decode(data)?;
-
+    pub async fn load_results(&self, data: &[u8]) -> Result<JobCtxs> {
         // Write the actual data to the result file so we can have JobCtxs load it.
         let mut file = std::fs::File::create(RESULT_PATH)?;
         file.write_all(&data)?;
 
         JobCtxs::load_results(RESULT_PATH)
+    }
+
+    pub async fn s3_object_exists(&self, object_name: &str) -> Result<bool> {
+        let output = self
+            .s3
+            .get_object()
+            .bucket("iocost-submit")
+            .key(object_name)
+            .send()
+            .await;
+
+        match output {
+            Ok(_) => Ok(true),
+            Err(SdkError::ServiceError {
+                err:
+                    GetObjectError {
+                        kind: GetObjectErrorKind::NoSuchKey(..),
+                        ..
+                    },
+                ..
+            }) => Ok(false),
+            Err(e) => Err(anyhow!(e)),
+        }
     }
 
     pub async fn save_to_s3(&self, object_name: &str) -> Result<String> {
@@ -133,7 +165,7 @@ impl LambdaHelper {
         let issue = octocrab::OctocrabBuilder::new()
             .personal_token(token)
             .build()?
-            .issues("iocost-benchmark", "iocost-benchmarks")
+            .issues("kov", "iocost-benchmarks")
             .create(title)
             .body(body)
             .send()
@@ -142,8 +174,19 @@ impl LambdaHelper {
         Ok(issue.html_url.to_string())
     }
 
-    pub fn object_name_from_hash(&self, data: &str) -> String {
-        format!("result-{:x}.json.gz", md5::compute(data.as_bytes()))
+    pub fn object_name_from_hash(&self, data: &[u8]) -> Result<String> {
+        // Use the actual content for the hash to avoid adding duplicates just because
+        // of differences in the compression.
+        let mut uncompressed_data = Vec::<u8>::new();
+        libflate::gzip::Decoder::new(Cursor::new(&data))
+            .context("Creating gzip decoder")?
+            .read_to_end(&mut uncompressed_data)
+            .context("Decompressing")?;
+
+        Ok(format!(
+            "result-{:x}.json.gz",
+            md5::compute(uncompressed_data)
+        ))
     }
 
     pub fn format_sysinfo(&self, jctxs: &JobCtxs) -> Result<String> {
@@ -183,6 +226,32 @@ impl LambdaHelper {
         }
 
         Ok(summary)
+    }
+
+    pub fn format_submitter_info(&self, request: &Request) -> String {
+        let mut id_str = String::new();
+
+        if let Some(email) = &request.email {
+            id_str.push_str("Submitter email: ");
+            id_str.push_str(email);
+            id_str.push_str("\n");
+        }
+
+        if let Some(github) = &request.github {
+            id_str.push_str("Submitter github user: ");
+            if !github.starts_with('@') {
+                id_str.push('@');
+            }
+            id_str.push_str(github);
+            id_str.push_str("\n");
+        }
+
+        // Add some spacing around what we have.
+        if !id_str.is_empty() {
+            return format!("\n\n{}\n\n", id_str);
+        }
+
+        id_str
     }
 }
 


### PR DESCRIPTION
The upload subcommand is the client for the AWS lambda function. It
validates the result file and uploads it to the function for an issue to
be created automatically.

Optional parameters allow the user to include their email address or
github handle in the issue.

The lambda has been improved to use that data and to be better at
identifying duplicates.

Signed-off-by: Gustavo Noronha Silva <gustavo.noronha@collabora.com>