### PR TITLE
More forgiving amof

### DIFF
--- a/rd-hashd/src/bench.rs
+++ b/rd-hashd/src/bench.rs
@@ -649,7 +649,7 @@ impl Bench {
     fn time_hash(size: usize, params: &Params, tf: &TestFiles) -> f64 {
         let mut hasher = hasher::Hasher::new(1.0, 0.0);
         let chunk_size = params.chunk_pages * *PAGE_SIZE;
-        let chunks_per_unit = (tf.unit_size as usize).div_ceil(&chunk_size);
+        let chunks_per_unit = Integer::div_ceil(&(tf.unit_size as usize), &chunk_size);
 
         let started_at = Instant::now();
 

--- a/rd-hashd/src/hasher.rs
+++ b/rd-hashd/src/hasher.rs
@@ -580,9 +580,9 @@ impl DispatchThread {
             // determined by each hash worker to avoid overloading the
             // dispatch thread.
             let file_size = self.file_size_normal.sample(&mut rng).round() as usize;
-            let file_nr_chunks = file_size.div_ceil(&chunk_size).max(1);
+            let file_nr_chunks = Integer::div_ceil(&file_size, &chunk_size).max(1);
             let anon_size = self.anon_size_normal.sample(&mut rng).round() as usize;
-            let anon_nr_chunks = anon_size.div_ceil(&chunk_size);
+            let anon_nr_chunks = Integer::div_ceil(&anon_size, &chunk_size);
 
             let hasher_thread = HasherThread {
                 tf: self.tf.clone(),

--- a/rd-hashd/src/testfiles.rs
+++ b/rd-hashd/src/testfiles.rs
@@ -35,7 +35,7 @@ impl TestFiles {
             base_path: PathBuf::from(base_path.as_ref()),
             unit_size,
             size,
-            nr_files: size.div_ceil(&unit_size),
+            nr_files: Integer::div_ceil(&size, &unit_size),
             comp,
             prefix: String::from(DFL_PREFIX),
         }

--- a/rd-util/src/anon_area.rs
+++ b/rd-util/src/anon_area.rs
@@ -61,7 +61,7 @@ impl AnonArea {
 
     pub fn resize(&mut self, mut size: usize) {
         size = size.max(Self::UNIT_SIZE);
-        let nr = size.div_ceil(&Self::UNIT_SIZE);
+        let nr = Integer::div_ceil(&size, &Self::UNIT_SIZE);
 
         self.units.truncate(nr);
         self.units.reserve(nr);

--- a/resctl-bench/doc/iocost-qos.md
+++ b/resctl-bench/doc/iocost-qos.md
@@ -227,3 +227,13 @@ writes.
 The minimum and maximum bounds for vrate adjustments. The value is in
 percentage where 100.0 means no scaling of the model parameters. If `min` ==
 `max`, vrate is fixed at the value.
+
+
+Format properties
+-----------------
+
+#### `sub-full` (boolean, default: false)
+
+By default, `iocost-qos` formats only the summaries of the storage and
+protection sub-benches. When `sub-full` is specified, each sub-bench will
+format the full result including resource and memory stats.

--- a/resctl-bench/doc/iocost-tune.md
+++ b/resctl-bench/doc/iocost-tune.md
@@ -196,7 +196,7 @@ scales the model parameters so that the QoS `max` always ends up 100%.
 `iocost-tune` can also generate a pdf file containing all the results:
 
 ```
-   $ resctl-bench -r result.json format iocost-tune:pdf=result.pdf
+   $ resctl-bench -r result.json format iocost-tune:pdf
 ```
 
 
@@ -352,3 +352,13 @@ The minimum vrate point where the specified MOF is at maximum.
 
 Solves for the `isolated bandwidth` and `isolation` solution described above
 respectively.
+
+
+Format properties
+-----------------
+
+#### `pdf` (String)
+
+Generate a pdf file containing the result summary and graphs. If no value is
+specified, `RESULT_PATH_STEM.pdf` is used where `RESULT_PATH_STEM` is the
+file stem of the global `--result` path.

--- a/resctl-bench/doc/iocost-tune.md
+++ b/resctl-bench/doc/iocost-tune.md
@@ -96,9 +96,10 @@ isolation.
 
 #### `isolated-bandwidth` 
 
-This targets the maximum vrate which provides the lowest latency impact,
-clamped between the `isolation` and `bandwidth` solutions. This is the vrate
-below which the isolation quality doesn't improve.
+This targets the maximum vrate at which `rd-hashd`'s isolatable memory
+footprint is the biggest clamped between the `isolation` and `bandwidth`
+solutions. This is the vrate at which the biggest memory footprint can be
+isolated.
 
 #### `isolation`
 

--- a/resctl-bench/doc/iocost-tune.md
+++ b/resctl-bench/doc/iocost-tune.md
@@ -259,11 +259,6 @@ Properties
 First group properties (applies to all sub-runs)
 ------------------------------------------------
 
-#### `gran` (float, default: 0.1)
-
-The granularity used when fitting lines to data points. The finer the
-granularity, the more cycles are needed.
-
 #### `scale-min` (fraction, default: 0.01)
 
 The minimum scale factor. No solution will scale below. See `scale-max`.

--- a/resctl-bench/src/bench/iocost_qos.rs
+++ b/resctl-bench/src/bench/iocost_qos.rs
@@ -2,6 +2,7 @@
 use super::*;
 use rand::Rng;
 
+use super::protection::mem_hog_tune::{DFL_ISOL_PCT, DFL_ISOL_THR};
 use super::protection::{self, ProtectionJob, ProtectionRecord, ProtectionResult};
 use super::storage::{StorageJob, StorageRecord, StorageResult};
 use rd_agent_intf::BenchKnobs;
@@ -13,8 +14,6 @@ const DFL_VRATE_MAX: f64 = 100.0;
 const DFL_VRATE_INTVS: u32 = 5;
 const DFL_STOR_BASE_LOOPS: u32 = 3;
 const DFL_STOR_LOOPS: u32 = 1;
-const DFL_ISOL_PCT: &'static str = "01";
-const DFL_ISOL_THR: f64 = 0.9;
 const DFL_RETRIES: u32 = 1;
 
 // Don't go below 1% of the specified model when applying vrate-intvs.

--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -3,6 +3,7 @@ use super::iocost_qos::{
     IoCostQoSJob, IoCostQoSRecord, IoCostQoSRecordRun, IoCostQoSResult, IoCostQoSResultRun,
 };
 use super::protection::MemHog;
+use super::protection::mem_hog_tune::{DFL_ISOL_PCT, DFL_ISOL_THR};
 use super::*;
 use statrs::distribution::{ContinuousCDF, Normal};
 use std::cell::RefCell;
@@ -1977,7 +1978,7 @@ impl Job for IoCostTuneJob {
                 let tune = recr.prot.scenarios[0].as_mem_hog_tune().unwrap();
                 (tune.isol_pct.clone(), tune.isol_thr)
             }
-            _ => ("01".to_string(), 0.9),
+            _ => (DFL_ISOL_PCT.to_string(), DFL_ISOL_THR),
         };
 
         for sel in self.sels.iter() {

--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -2,8 +2,8 @@
 use super::iocost_qos::{
     IoCostQoSJob, IoCostQoSRecord, IoCostQoSRecordRun, IoCostQoSResult, IoCostQoSResultRun,
 };
-use super::protection::MemHog;
 use super::protection::mem_hog_tune::{DFL_ISOL_PCT, DFL_ISOL_THR};
+use super::protection::MemHog;
 use super::*;
 use statrs::distribution::{ContinuousCDF, Normal};
 use std::cell::RefCell;
@@ -2089,9 +2089,16 @@ impl Job for IoCostTuneJob {
         for (k, v) in props[0].iter() {
             match k.as_ref() {
                 "pdf" => {
-                    if v.len() > 0 {
-                        pdf_path = Some(v.to_owned());
-                    }
+                    pdf_path = Some(if v.len() > 0 {
+                        v.to_owned()
+                    } else {
+                        Path::new(opts.result_path)
+                            .file_stem()
+                            .unwrap()
+                            .to_string_lossy()
+                            .to_string()
+                            + ".pdf"
+                    });
                 }
                 "pdf-keep" => pdf_keep = v.len() == 0 || v.parse::<bool>()?,
                 k => bail!("unknown format parameter {:?}", k),

--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -1192,6 +1192,20 @@ impl DataLines {
 
         Ok(clamped)
     }
+
+    fn min_max(&self) -> (f64, f64) {
+        self.points
+            .iter()
+            .fold((std::f64::MAX, std::f64::MIN), |mut min_max, pt| {
+                if pt.y < min_max.0 {
+                    min_max.0 = pt.y;
+                }
+                if pt.y > min_max.1 {
+                    min_max.1 = pt.y;
+                }
+                min_max
+            })
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]

--- a/resctl-bench/src/bench/iocost_tune/graph.rs
+++ b/resctl-bench/src/bench/iocost_tune/graph.rs
@@ -66,25 +66,26 @@ impl<'a, 'b> Grapher<'a, 'b> {
         };
         let ymax = (val_max * 1.1).max((ymin) + 0.000001);
 
-        let lines = &series.lines;
-        let mut xlabel = format!(
-            "vrate {:.1}-{:.1} (",
-            series.lines.range.0, series.lines.range.1
+        let (range, left, right) = (
+            series.lines.range,
+            series.lines.left.unwrap(),
+            series.lines.right.unwrap(),
         );
-        if lines.left.y == lines.right.y {
-            xlabel += &format!("mean={:.3} ", lines.left.y * yscale)
+        let mut xlabel = format!("vrate {:.1}-{:.1} (", range.0, range.1);
+        if left.y == right.y {
+            xlabel += &format!("mean={:.3} ", left.y * yscale)
         } else {
             xlabel += &format!(
                 "min={:.3} max={:.3} ",
-                lines.left.y.min(lines.right.y) * yscale,
-                lines.left.y.max(lines.right.y) * yscale
+                left.y.min(right.y) * yscale,
+                left.y.max(right.y) * yscale
             )
         }
-        if lines.left.x > series.lines.range.0 {
-            xlabel += &format!("L-infl={:.1} ", lines.left.x);
+        if left.x > range.0 {
+            xlabel += &format!("L-infl={:.1} ", left.x);
         }
-        if lines.right.x < series.lines.range.1 {
-            xlabel += &format!("R-infl={:.1} ", lines.right.x);
+        if right.x < range.1 {
+            xlabel += &format!("R-infl={:.1} ", right.x);
         }
         xlabel += &format!("err={:.3})", series.error * yscale);
 
@@ -186,15 +187,19 @@ impl<'a, 'b> Grapher<'a, 'b> {
             ),
         );
 
-        let lines = &series.lines;
+        let (range, left, right) = (
+            series.lines.range,
+            series.lines.left.unwrap(),
+            series.lines.right.unwrap(),
+        );
         let mut segments = vec![];
-        if series.lines.range.0 < lines.left.x {
-            segments.push((series.lines.range.0, lines.left.y * yscale));
+        if range.0 < left.x {
+            segments.push((range.0, left.y * yscale));
         }
-        segments.push((lines.left.x, lines.left.y * yscale));
-        segments.push((lines.right.x, lines.right.y * yscale));
-        if series.lines.range.1 > lines.right.x {
-            segments.push((series.lines.range.1, lines.right.y * yscale));
+        segments.push((left.x, left.y * yscale));
+        segments.push((right.x, right.y * yscale));
+        if range.1 > right.x {
+            segments.push((range.1, right.y * yscale));
         }
 
         let view = view.add(Plot::new(segments).line_style(LineStyle::new().colour("#3749e6")));

--- a/resctl-bench/src/bench/iocost_tune/graph.rs
+++ b/resctl-bench/src/bench/iocost_tune/graph.rs
@@ -30,7 +30,7 @@ impl<'a, 'b> Grapher<'a, 'b> {
         extra_info: Option<&str>,
     ) -> (ContinuousView, f64) {
         let (val_min, val_max) = series
-            .points
+            .data
             .iter()
             .chain(series.outliers.iter())
             .fold((std::f64::MAX, 0.0_f64), |acc, point| {
@@ -134,7 +134,7 @@ impl<'a, 'b> Grapher<'a, 'b> {
         let view =
             view.add(Plot::new(outliers).point_style(PointStyle::new().marker(PointMarker::Cross)));
 
-        let points = series.points.iter().map(|p| (p.x, p.y * yscale)).collect();
+        let points = series.data.iter().map(|p| (p.x, p.y * yscale)).collect();
         let view =
             view.add(Plot::new(points).point_style(PointStyle::new().marker(PointMarker::Circle)));
 
@@ -175,7 +175,7 @@ impl<'a, 'b> Grapher<'a, 'b> {
             ),
         );
 
-        let points = series.points.iter().map(|p| (p.x, p.y * yscale)).collect();
+        let points = series.data.iter().map(|p| (p.x, p.y * yscale)).collect();
         view = view.add(
             Plot::new(points).point_style(
                 PointStyle::new()

--- a/resctl-bench/src/bench/iocost_tune/graph.rs
+++ b/resctl-bench/src/bench/iocost_tune/graph.rs
@@ -153,7 +153,7 @@ impl<'a, 'b> Grapher<'a, 'b> {
         extra_info: &str,
     ) -> Result<()> {
         const SIZE: (u32, u32) = (576, 468);
-        let (view, yscale) = Self::setup_view(
+        let (mut view, yscale) = Self::setup_view(
             self.vrate_range,
             sel,
             series,
@@ -167,7 +167,7 @@ impl<'a, 'b> Grapher<'a, 'b> {
             .iter()
             .map(|p| (p.x, p.y * yscale))
             .collect();
-        let view = view.add(
+        view = view.add(
             Plot::new(points).point_style(
                 PointStyle::new()
                     .marker(PointMarker::Cross)
@@ -176,7 +176,7 @@ impl<'a, 'b> Grapher<'a, 'b> {
         );
 
         let points = series.points.iter().map(|p| (p.x, p.y * yscale)).collect();
-        let view = view.add(
+        view = view.add(
             Plot::new(points).point_style(
                 PointStyle::new()
                     .marker(PointMarker::Circle)
@@ -190,10 +190,11 @@ impl<'a, 'b> Grapher<'a, 'b> {
             .iter()
             .map(|pt| (pt.x, pt.y * yscale))
             .collect();
+        if !segments.is_empty() {
+            view = view.add(Plot::new(segments).line_style(LineStyle::new().colour("#3749e6")));
+        }
 
-        let view = view.add(Plot::new(segments).line_style(LineStyle::new().colour("#3749e6")));
-
-        let view = view.x_max_ticks(10).y_max_ticks(10);
+        view = view.x_max_ticks(10).y_max_ticks(10);
 
         let mut path = PathBuf::from(dir);
         path.push(format!("iocost-tune-{}.svg", sel));

--- a/resctl-bench/src/bench/iocost_tune/merge.rs
+++ b/resctl-bench/src/bench/iocost_tune/merge.rs
@@ -148,7 +148,7 @@ pub fn merge(srcs: &mut Vec<MergeSrc>) -> Result<JobData> {
                     data.get_mut(&sel).unwrap()
                 }
             };
-            dst_ds.points.append(&mut src_ds.points);
+            dst_ds.data.append(&mut src_ds.data);
             dst_ds.outliers.append(&mut src_ds.outliers);
         }
     }

--- a/resctl-bench/src/bench/protection.rs
+++ b/resctl-bench/src/bench/protection.rs
@@ -3,7 +3,7 @@ use super::*;
 use std::collections::BTreeMap;
 
 mod mem_hog;
-mod mem_hog_tune;
+pub mod mem_hog_tune;
 pub use mem_hog::{MemHog, MemHogRecord, MemHogResult, MemHogSpeed};
 pub use mem_hog_tune::{MemHogTune, MemHogTuneRecord, MemHogTuneResult};
 

--- a/resctl-bench/src/bench/protection/mem_hog_tune.rs
+++ b/resctl-bench/src/bench/protection/mem_hog_tune.rs
@@ -2,6 +2,9 @@
 use super::super::*;
 use super::mem_hog::{MemHog, MemHogRecord, MemHogResult, MemHogSpeed};
 
+pub const DFL_ISOL_PCT: &'static str = "05";
+pub const DFL_ISOL_THR: f64 = 0.9;
+
 #[derive(Clone, Debug)]
 pub struct MemHogTune {
     pub load: f64,
@@ -21,8 +24,8 @@ impl Default for MemHogTune {
             speed: dfl_hog.speed,
             size_range: (0, 0),
             intvs: 10,
-            isol_pct: "01".to_owned(),
-            isol_thr: 0.9,
+            isol_pct: DFL_ISOL_PCT.to_owned(),
+            isol_thr: DFL_ISOL_THR,
             dur: 200.0,
         }
     }

--- a/resctl-bench/src/job.rs
+++ b/resctl-bench/src/job.rs
@@ -19,9 +19,10 @@ use rd_util::*;
 use resctl_bench_intf::{JobProps, JobSpec, Mode};
 
 #[derive(Debug, Clone)]
-pub struct FormatOpts {
+pub struct FormatOpts<'a> {
     pub full: bool,
     pub rstat: u32,
+    pub result_path: &'a str,
 }
 
 pub trait Job {

--- a/resctl-bench/src/main.rs
+++ b/resctl-bench/src/main.rs
@@ -420,12 +420,18 @@ impl Program {
         }
 
         let rstat = args.rstat;
+        let result_path = args.result.clone();
         match args.mode {
             Mode::Run | Mode::Study | Mode::Solve => self.do_run(),
-            Mode::Format => self.do_format(&FormatOpts { full: true, rstat }),
+            Mode::Format => self.do_format(&FormatOpts {
+                full: true,
+                rstat,
+                result_path: &result_path,
+            }),
             Mode::Summary => self.do_format(&FormatOpts {
                 full: false,
                 rstat: 0,
+                result_path: &result_path,
             }),
             #[cfg(feature = "lambda")]
             Mode::Lambda => lambda::run().unwrap(),

--- a/resctl-bench/src/merge.rs
+++ b/resctl-bench/src/merge.rs
@@ -210,6 +210,7 @@ pub fn merge(args: &Args) -> Result<()> {
             &FormatOpts {
                 full: true,
                 rstat: 0,
+                result_path: &args.result,
             },
             &vec![Default::default()],
         )

--- a/resctl-bench/src/run.rs
+++ b/resctl-bench/src/run.rs
@@ -1251,6 +1251,7 @@ impl<'a, 'b> RunCtx<'a, 'b> {
             &FormatOpts {
                 full: false,
                 rstat: 0,
+                result_path: &self.args.result,
             },
             &vec![Default::default()],
         )

--- a/resctl-bench/src/study/rstat.rs
+++ b/resctl-bench/src/study/rstat.rs
@@ -274,6 +274,7 @@ pub struct ResourceStat {
     pub cpu_util: PctsMap,
     pub cpu_sys: PctsMap,
     pub mem_bytes: PctsMap,
+    pub swap_bytes: PctsMap,
     pub io_util: PctsMap,
     pub io_bps: (PctsMap, PctsMap),
     pub psi_cpu: PctsMap,
@@ -348,6 +349,7 @@ impl ResourceStat {
         print_pcts_line(out, fn_len, "cpu%", &self.cpu_util, format_pct, None);
         print_pcts_line(out, fn_len, "sys%", &self.cpu_sys, format_pct, None);
         print_pcts_line(out, fn_len, "mem", &self.mem_bytes, format_size, None);
+        print_pcts_line(out, fn_len, "swap", &self.swap_bytes, format_size, None);
         print_pcts_line(out, fn_len, "io%", &self.io_util, format_pct, None);
         print_pcts_line(out, fn_len, "rbps", &self.io_bps.0, format_size, None);
         print_pcts_line(out, fn_len, "wbps", &self.io_bps.1, format_size, None);
@@ -432,6 +434,7 @@ pub struct ResourceStatStudy<'a> {
     cpu_util_study: Box<dyn StudyMeanPctsTrait + 'a>,
     cpu_sys_study: Box<dyn StudyMeanPctsTrait + 'a>,
     mem_bytes_study: Box<dyn StudyMeanPctsTrait + 'a>,
+    swap_bytes_study: Box<dyn StudyMeanPctsTrait + 'a>,
     io_util_study: Box<dyn StudyMeanPctsTrait + 'a>,
     io_bps_studies: (
         Box<dyn StudyMeanPctsTrait + 'a>,
@@ -523,6 +526,10 @@ impl<'a> ResourceStatStudy<'a> {
             )),
             mem_bytes_study: Box::new(StudyMeanPcts::new(
                 move |arg| [arg.rep.usages[name].mem_bytes].repeat(arg.cnt),
+                None,
+            )),
+            swap_bytes_study: Box::new(StudyMeanPcts::new(
+                move |arg| [arg.rep.usages[name].swap_bytes].repeat(arg.cnt),
                 None,
             )),
             io_util_study: Box::new(StudyMeanPcts::new(
@@ -617,6 +624,7 @@ impl<'a> ResourceStatStudy<'a> {
             self.cpu_util_study.as_study_mut(),
             self.cpu_sys_study.as_study_mut(),
             self.mem_bytes_study.as_study_mut(),
+            self.swap_bytes_study.as_study_mut(),
             self.io_util_study.as_study_mut(),
             self.io_bps_studies.0.as_study_mut(),
             self.io_bps_studies.1.as_study_mut(),
@@ -642,6 +650,7 @@ impl<'a> ResourceStatStudy<'a> {
             cpu_util: self.cpu_util_study.result(pcts),
             cpu_sys: self.cpu_sys_study.result(pcts),
             mem_bytes: self.mem_bytes_study.result(pcts),
+            swap_bytes: self.swap_bytes_study.result(pcts),
             io_util: self.io_util_study.result(pcts),
             io_bps: (
                 self.io_bps_studies.0.result(pcts),


### PR DESCRIPTION
There are a couple important changes around iocost-tune aMOF handling.

The aMOF criterion was isol-01 being above 90%. This unfortunately turned out to be too strict for a lot of devices and we end up solutions which are very pessimistic or outright no solutions on lower end devices. Another problem is that it makes the benchmark too sensitive to disturbances which may not be coming from the IO device at all. Relax the criterion to isol-05, which is still a pretty strong guarantee while making the benchmark more robust.

aMOF is one of the most important metrics that iocost-tune uses in determining the parameter solutions. However, because of the limited line fitting that it could do, it wasn't very good at utilizing it - e.g. some, usually high performing, devices show aMOF graph which peaks in the middle - towards the left, it's getting throttled too much, and towards the right, isolation is too weak to protect rd-hashd. This peak is a natural point for the e.g. isolated-bandwidth solution. However, due to the limitations in line fitting, we couldn't detect this mid peak and instead relied on lat-imp to determine isolated-bandwidth which is an a lot less reliable metric. This pull request revamps line fitting and adds support for DataShape::SinglePeak to address this shortcoming and updates isolated-bandwidth to use aMOF peak instead of basing its decision on lat-imp.

This patchset also contains a number of other cleanups and updates. This is a compatibility breaking change. The json file format changes along with bench behavior and thus will be released as a new version (2.2.0).