### PR TITLE
agent: Enforce none iosched instead of mq-deadline

### DIFF
--- a/rd-agent/src/cmd.rs
+++ b/rd-agent/src/cmd.rs
@@ -472,14 +472,10 @@ impl Runner {
                 }
 
                 if data.cfg.enforce.io {
-                    let iosched = match data.state {
-                        BenchIoCost => "none",
-                        _ => "mq-deadline",
-                    };
-                    if let Err(e) = super::set_iosched(&data.cfg.scr_dev, iosched) {
+                    if let Err(e) = super::set_iosched(&data.cfg.scr_dev, "none") {
                         error!(
-                            "cfg: Failed to set {:?} iosched on {:?} ({})",
-                            iosched, &data.cfg.scr_dev, &e
+                            "cfg: Failed to set none iosched on {:?} ({})",
+                            &data.cfg.scr_dev, &e
                         );
                     }
                 }

--- a/rd-agent/src/main.rs
+++ b/rd-agent/src/main.rs
@@ -751,16 +751,16 @@ impl Config {
             }
         }
 
-        // mq-deadline scheduler
+        // none scheduler
         if self.enforce.io {
             if let Ok(v) = read_iosched(&self.scr_dev) {
                 self.sr_iosched = Some(v);
             }
-            if let Err(e) = set_iosched(&self.scr_dev, "mq-deadline") {
+            if let Err(e) = set_iosched(&self.scr_dev, "none") {
                 self.sr_failed.add(
                     SysReq::IoSched,
                     &format!(
-                        "Failed to set mq-deadline iosched on {:?} ({})",
+                        "Failed to set none iosched on {:?} ({})",
                         &self.scr_dev, &e
                     ),
                 );
@@ -769,11 +769,11 @@ impl Config {
 
         let scr_dev_iosched = match read_iosched(&self.scr_dev) {
             Ok(v) => {
-                if v != "mq-deadline" {
+                if v != "none" {
                     self.sr_failed.add(
                         SysReq::IoSched,
                         &format!(
-                            "cfg: iosched on {:?} is {} instead of mq-deadline",
+                            "cfg: iosched on {:?} is {} instead of none",
                             &self.scr_dev, v
                         ),
                     );

--- a/resctl-bench/README.md
+++ b/resctl-bench/README.md
@@ -90,7 +90,7 @@ Let's look at the result of the first benchmark - `hashd-params`.
                 passive=io
 
    IO info: dev=nvme0n1(259:0) model="WDC CL SN720 SDAQNTW-512G-1020" size=477G
-            iosched=mq-deadline wbt=off iocost=off other=off
+            iosched=none wbt=off iocost=off other=off
 
    Params: log_bps=1.0M
 
@@ -118,7 +118,7 @@ Let's now take a look at the first next result. Partial header:
    [protection result] "iocost-off" 2021-06-22 19:13:37 - 19:30:25
    ...
    IO info: dev=nvme0n1(259:0) model="WDC CL SN720 SDAQNTW-512G-1020" size=477G
-            iosched=mq-deadline wbt=off iocost=off other=off
+            iosched=none wbt=off iocost=off other=off
 ```
 
 shows that this is `protection` result with ID `iocost-off`. Skipping over
@@ -171,7 +171,7 @@ Let's see whether the `protection` result is any better with `iocost` on:
    [protection result] "iocost-on" 2021-06-22 19:38:53 - 20:02:27
    ...
    IO info: dev=nvme0n1(259:0) model="WDC CL SN720 SDAQNTW-512G-1020" size=477G
-            iosched=mq-deadline wbt=off iocost=on other=off
+            iosched=none wbt=off iocost=on other=off
             iocost model: rbps=1348822120 rseqiops=235687 rrandiops=218614
                           wbps=601694170 wseqiops=133453 wrandiops=69308
             iocost QoS: rpct=95.00 rlat=19562 wpct=95.00 wlat=65667 min=60.00 max=100.00

--- a/resctl-bench/doc/common.md
+++ b/resctl-bench/doc/common.md
@@ -441,7 +441,7 @@ the following:
                 mem_profile=16 (avail=30.1G share=12.0G target=11.0G)
 
    IO info: dev=nvme0n1(259:5) model="Samsung SSD 970 PRO 512GB" size=477G
-            iosched=mq-deadline wbt=off iocost=on other=off
+            iosched=none wbt=off iocost=on other=off
             iocost model: rbps=2992129542 rseqiops=337745 rrandiops=370705
                           wbps=2232405244 wseqiops=260917 wrandiops=256225
             iocost QoS: rpct=95.00 rlat=11649 wpct=95.00 wlat=12681 min=8.83 max=8.83

--- a/resctl-bench/examples/prot-iocost-off-on-format.txt
+++ b/resctl-bench/examples/prot-iocost-off-on-format.txt
@@ -8,7 +8,7 @@ System info: kernel="5.6.13-0_fbk16_5756_gdcbe47195163"
              passive=io
 
 IO info: dev=nvme0n1(259:0) model="WDC CL SN720 SDAQNTW-512G-1020" size=477G
-         iosched=mq-deadline wbt=off iocost=off other=off
+         iosched=none wbt=off iocost=off other=off
 
 Params: log_bps=1.0M
 
@@ -24,7 +24,7 @@ System info: kernel="5.6.13-0_fbk16_5756_gdcbe47195163"
              passive=io
 
 IO info: dev=nvme0n1(259:0) model="WDC CL SN720 SDAQNTW-512G-1020" size=477G
-         iosched=mq-deadline wbt=off iocost=off other=off
+         iosched=none wbt=off iocost=off other=off
 
 hashd params: hash_size=1.2M rps_max=1029 mem_actual=16.1G chunk_pages=25
 
@@ -321,7 +321,7 @@ System info: kernel="5.6.13-0_fbk16_5756_gdcbe47195163"
              mem_profile=16 (avail=58.3G share=12.0G target=11.0G)
 
 IO info: dev=nvme0n1(259:0) model="WDC CL SN720 SDAQNTW-512G-1020" size=477G
-         iosched=mq-deadline wbt=off iocost=off other=off
+         iosched=none wbt=off iocost=off other=off
 
 iocost model: rbps=1348822120 rseqiops=235687 rrandiops=218614
               wbps=601694170 wseqiops=133453 wrandiops=69308
@@ -336,7 +336,7 @@ System info: kernel="5.6.13-0_fbk16_5756_gdcbe47195163"
              mem_profile=16 (avail=58.3G share=12.0G target=11.0G)
 
 IO info: dev=nvme0n1(259:0) model="WDC CL SN720 SDAQNTW-512G-1020" size=477G
-         iosched=mq-deadline wbt=off iocost=on other=off
+         iosched=none wbt=off iocost=on other=off
          iocost model: rbps=1348822120 rseqiops=235687 rrandiops=218614
                        wbps=601694170 wseqiops=133453 wrandiops=69308
          iocost QoS: rpct=95.00 rlat=19562 wpct=95.00 wlat=65667 min=60.00 max=100.00

--- a/resctl-demo/src/doc/intro.sysreqs.rd
+++ b/resctl-demo/src/doc/intro.sysreqs.rd
@@ -94,11 +94,11 @@ it's currently unmet:
   The filesystem must be on a physical device.
 
 * %SysReq::IoSched%: bfq IO scheduler's implementation of proportional IO
-  control conflicts with blk-iocost and breaks IO isolation. Use
-  mq-deadline.
+  control conflicts with blk-iocost and breaks IO isolation. Use none.
 
-  IO scheduler can be selected by writing to /sys/block/$DEV/queue/scheduler.
-  resctl-demo automatically switches to mq-deadline if available.
+  IO scheduler can be selected by writing to
+  /sys/block/$DEV/queue/scheduler. resctl-demo automatically switches to
+  none.
 
 * %SysReq::NoWbt%: Write-Back-Throttling is a block layer mechanism to prevent
   writebacks from overwhelming IO devices. This may interfere with IO control


### PR DESCRIPTION
There's no tangible benefits to using mq-deadline and it gets in the way on
high iops devices. Use none iosched instead.