### PR TITLE
agent: iocost_coef_gen.py: Allow trim commands to fail

### DIFF
--- a/rd-agent/src/misc/iocost_coef_gen.py
+++ b/rd-agent/src/misc/iocost_coef_gen.py
@@ -274,7 +274,7 @@ if args.testdev:
     info(f'Test target: {devname}({devnr})')
     if not args.no_trim:
         info(f'Trimming...')
-        subprocess.check_call(f'blkdiscard -f /dev/{devname}', shell=True)
+        subprocess.call(f'blkdiscard -f /dev/{devname}', shell=True)
 else:
     if args.testfile_dev:
         devname = os.path.basename(args.testfile_dev)
@@ -296,7 +296,7 @@ else:
 
     if not args.no_trim:
         info(f'Trimming...')
-        subprocess.check_call(f'fstrim -v $(findmnt -n -o TARGET --target .)', shell=True)
+        subprocess.call(f'fstrim -v $(findmnt -n -o TARGET --target .)', shell=True)
 
 dev_path = f'/sys/block/{devname}'
 elevator_path = f'{dev_path}/queue/scheduler'


### PR DESCRIPTION
On hard disks or other devices which don't support trim, the trim commands
will fail. We still wanna proceed with the benchmark. Ignore the failures.