### PR TITLE
bench: iocost-tune: Escape special chars in graph axis labels when ge…

### DIFF
--- a/resctl-bench/src/bench/iocost_tune/graph.rs
+++ b/resctl-bench/src/bench/iocost_tune/graph.rs
@@ -21,6 +21,21 @@ impl<'a, 'b> Grapher<'a, 'b> {
         }
     }
 
+    fn escape_xml(input: &str) -> String {
+        let mut escaped = String::new();
+        for ch in input.chars() {
+            match ch {
+                '<' => escaped += "&lt;",
+                '>' => escaped += "&gt;",
+                '&' => escaped += "&#38;",
+                '\'' => escaped += "&#39;",
+                '"' => escaped += "&#34;",
+                ch => escaped.push(ch),
+            }
+        }
+        escaped
+    }
+
     fn setup_view(
         vrate_range: (f64, f64),
         sel: &DataSel,
@@ -98,8 +113,8 @@ impl<'a, 'b> Grapher<'a, 'b> {
         let view = ContinuousView::new()
             .x_range(0.0, (vrate_range.1 * 1.1).max(0.000001))
             .y_range(ymin * yscale, ymax * yscale)
-            .x_label(xlabel)
-            .y_label(ylabel);
+            .x_label(Self::escape_xml(&xlabel))
+            .y_label(Self::escape_xml(&ylabel));
 
         (view, yscale)
     }


### PR DESCRIPTION
…nerating svgs

plotlib emits axis labels verbatim which can break the generated svg. e.g.
if the device model string can't be determined, it's set to "<UNKNOWN>"
which, when emitted without escaping, breaks the xml parsing. Fix it by
escaping xml special chars.