### PR TITLE
Merge summary

### DIFF
--- a/rd-agent/src/main.rs
+++ b/rd-agent/src/main.rs
@@ -759,10 +759,7 @@ impl Config {
             if let Err(e) = set_iosched(&self.scr_dev, "none") {
                 self.sr_failed.add(
                     SysReq::IoSched,
-                    &format!(
-                        "Failed to set none iosched on {:?} ({})",
-                        &self.scr_dev, &e
-                    ),
+                    &format!("Failed to set none iosched on {:?} ({})", &self.scr_dev, &e),
                 );
             }
         }

--- a/resctl-bench/doc/iocost-tune.md
+++ b/resctl-bench/doc/iocost-tune.md
@@ -358,3 +358,9 @@ Format properties
 Generate a pdf file containing the result summary and graphs. If no value is
 specified, `RESULT_PATH_STEM.pdf` is used where `RESULT_PATH_STEM` is the
 file stem of the global `--result` path.
+
+#### `high-level` (bool)
+
+Asks for a very high level summary of the results. This is especially useful
+hen deciding from many sets of merged results (see Merging above) which one
+has more reliable parameters.

--- a/resctl-bench/src/bench.rs
+++ b/resctl-bench/src/bench.rs
@@ -153,6 +153,7 @@ pub struct BenchDesc {
 
     pub mergeable: bool,
     pub merge_by_storage_model: bool,
+    pub merge_by_storage_fwver: bool,
 }
 
 #[allow(dead_code)]
@@ -204,6 +205,11 @@ impl BenchDesc {
 
     pub fn merge_needs_storage_model(mut self) -> Self {
         self.merge_by_storage_model = true;
+        self
+    }
+
+    pub fn merge_needs_storage_fwver(mut self) -> Self {
+        self.merge_by_storage_fwver = true;
         self
     }
 }

--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -973,6 +973,7 @@ impl Bench for IoCostTuneBench {
         .incremental()
         .mergeable()
         .merge_needs_storage_model()
+        .merge_needs_storage_fwver()
     }
 
     fn parse(&self, spec: &JobSpec, _prev_data: Option<&JobData>) -> Result<Box<dyn Job>> {

--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -818,11 +818,8 @@ impl QoSTarget {
 
         // Find the max vrate at max val.
         let solve_right_max = |sel| -> Result<Option<f64>> {
-            let sol = Self::find_max_vrate_at_max_val(
-                ds(sel)?,
-                (scale_min, scale_max),
-                infl_offset(),
-            );
+            let sol =
+                Self::find_max_vrate_at_max_val(ds(sel)?, (scale_min, scale_max), infl_offset());
             trace!("solve_max_right sel={:?} sol={:?}", sel, sol);
             Ok(sol)
         };
@@ -1971,6 +1968,18 @@ impl QoSSolution {
             ..other.clone()
         }
     }
+
+    fn cmp_mof<'r, 's>(a: &'r &&QoSSolution, b: &'s &&QoSSolution) -> Ordering {
+        a.mem_offload_factor
+            .partial_cmp(&b.mem_offload_factor)
+            .unwrap()
+    }
+
+    fn cmp_amof<'r, 's>(a: &'r &&QoSSolution, b: &'s &&QoSSolution) -> Ordering {
+        a.adjusted_mem_offload_factor
+            .partial_cmp(&b.adjusted_mem_offload_factor)
+            .unwrap()
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug)]
@@ -2228,6 +2237,65 @@ impl IoCostTuneJob {
         }
 
         remarks
+    }
+
+    fn format_high_level<'a>(&self, out: &mut Box<dyn Write + 'a>, res: &IoCostTuneResult) {
+        writeln!(out, "[iocost-tune result]\n").unwrap();
+
+        let reference = res.data.get(&DataSel::MOF).unwrap();
+        let num_points = reference.data.len() + reference.outliers.len();
+        let solutions: Vec<&QoSSolution> = res.solutions.values().collect();
+        writeln!(
+            out,
+            "{} points, MOF=[{:.3},{:.3}], aMOF=[{:.3},{:.3}]",
+            num_points,
+            solutions
+                .iter()
+                .min_by(QoSSolution::cmp_mof)
+                .unwrap()
+                .mem_offload_factor,
+            solutions
+                .iter()
+                .max_by(QoSSolution::cmp_mof)
+                .unwrap()
+                .mem_offload_factor,
+            solutions
+                .iter()
+                .min_by(QoSSolution::cmp_amof)
+                .unwrap()
+                .adjusted_mem_offload_factor,
+            solutions
+                .iter()
+                .max_by(QoSSolution::cmp_amof)
+                .unwrap()
+                .adjusted_mem_offload_factor
+        )
+        .unwrap();
+
+        let model = &res.base_model;
+
+        writeln!(
+            out,
+            "base model: rbps={:.1} rseqiops={} rrandiops={} wbps={:.1} wseqiops={} wrandiops={}",
+            format_size(model.rbps),
+            format_size(model.rseqiops),
+            format_size(model.rrandiops),
+            format_size(model.wbps),
+            format_size(model.wseqiops),
+            format_size(model.wrandiops)
+        )
+        .unwrap();
+
+        // Use rule names to index solutions so we get the same order as the used in
+        // iocost-tune results full form format.
+        let mut solutions = vec![];
+        for rule in self.rules.iter() {
+            let sol = res.solutions.get(&rule.name).unwrap();
+            solutions.push(format!("{}={}%", &rule.name, format_pct(sol.scale_factor)));
+        }
+
+        writeln!(out, "solutions : {}", &solutions[0..4].join(" ")).unwrap();
+        writeln!(out, "            {}", &solutions[4..].join(" ")).unwrap();
     }
 
     fn format_rules<'a>(out: &mut Box<dyn Write + 'a>, rules: &[&QoSRule]) {
@@ -2596,8 +2664,11 @@ impl Job for IoCostTuneJob {
         opts: &FormatOpts,
         props: &JobProps,
     ) -> Result<()> {
+        let res: IoCostTuneResult = data.parse_result()?;
+
         let mut pdf_path = None;
         let mut pdf_keep = false;
+        let mut high_level = false;
         for (k, v) in props[0].iter() {
             match k.as_ref() {
                 "pdf" => {
@@ -2613,11 +2684,19 @@ impl Job for IoCostTuneJob {
                     });
                 }
                 "pdf-keep" => pdf_keep = v.len() == 0 || v.parse::<bool>()?,
+                "high-level" => high_level = v.len() == 0 || v.parse::<bool>()?,
                 k => bail!("unknown format parameter {:?}", k),
             }
         }
 
-        let res: IoCostTuneResult = data.parse_result()?;
+        if pdf_path.is_some() && high_level {
+            bail!("format parameter merge-info is incompatible with pdf")
+        }
+
+        if high_level {
+            self.format_high_level(out, &res);
+            return Ok(());
+        }
 
         let vrate_range = res
             .data

--- a/resctl-bench/src/job.rs
+++ b/resctl-bench/src/job.rs
@@ -476,7 +476,20 @@ impl JobCtx {
         let mut buf = String::new();
         let mut out = Box::new(&mut buf) as Box<dyn Write>;
 
-        self.data.format_header(&mut out);
+        let mut is_high_level = false;
+        for map in props.iter() {
+            if let Some(v) = map.get("high-level") {
+                is_high_level = v.len() > 0 || v.parse::<bool>().unwrap_or(false);
+                break;
+            }
+        }
+
+        // For high level summaries we don't want to add a lot of boiler plate.
+        // Let the job itself decide everything that should be printed.
+        if !is_high_level {
+            self.data.format_header(&mut out);
+        }
+
         self.job
             .as_ref()
             .unwrap()

--- a/resctl-bench/src/lambda.rs
+++ b/resctl-bench/src/lambda.rs
@@ -165,7 +165,7 @@ impl LambdaHelper {
         let issue = octocrab::OctocrabBuilder::new()
             .personal_token(token)
             .build()?
-            .issues("kov", "iocost-benchmarks")
+            .issues("iocost-benchmark", "iocost-benchmarks")
             .create(title)
             .body(body)
             .send()

--- a/resctl-bench/src/lambda.rs
+++ b/resctl-bench/src/lambda.rs
@@ -208,7 +208,9 @@ impl LambdaHelper {
     pub fn format_summary(&self, jctxs: &JobCtxs) -> Result<String> {
         let format_opts = FormatOpts {
             full: false,
+            merge_only: false,
             rstat: 0,
+            result_path: RESULT_PATH,
         };
         let empty_props = vec![Default::default()];
 

--- a/resctl-bench/src/merge.rs
+++ b/resctl-bench/src/merge.rs
@@ -19,6 +19,7 @@ pub struct MergeId {
     pub versions: Option<(String, String, String)>,
     pub mem_profile: u32,
     pub storage_model: Option<String>,
+    pub storage_fwver: Option<String>,
     pub classifier: Option<String>,
 }
 
@@ -72,6 +73,10 @@ impl MergeSrc {
             mem_profile: si.mem.profile,
             storage_model: match desc.merge_by_storage_model {
                 true => Some(srep.scr_dev_model.clone()),
+                false => None,
+            },
+            storage_fwver: match desc.merge_by_storage_fwver {
+                true => Some(srep.scr_dev_fwrev.clone()),
                 false => None,
             },
             classifier: self.bench.merge_classifier(&self.data),

--- a/resctl-bench/src/merge/info.rs
+++ b/resctl-bench/src/merge/info.rs
@@ -89,6 +89,9 @@ impl MergeEntry {
         if let Some(storage) = self.mid.storage_model.as_ref() {
             writeln!(out, "  storage: {}", storage).unwrap();
         }
+        if let Some(fwver) = self.mid.storage_fwver.as_ref() {
+            writeln!(out, "  fwver: {}", fwver).unwrap();
+        }
         if let Some(cl) = self.mid.classifier.as_ref() {
             writeln!(out, "  classifier: {}", &cl).unwrap();
         }


### PR DESCRIPTION
I am wondering if we should just show the minimum number of points and the maximum for ouliers and errors instead of showing all of the solutions. What information would you like to have here? This is what it looks like right now:

```
==========================================================================================

[0] iocost-tune
  version: 2.2
  memory-profile: 16
  storage: Samsung SSD 970 PRO 512GB
  classifier: dither,vrate-max=125
  sources:
    + ../result-files/2.2/970pro.json.gz

==========================================================================================

[MOF]
23 points, 0 outliers, error: 0.005026878511151166

[isol]
23 points, 0 outliers, error: 0.002473790887859725

[aMOF]
23 points, 0 outliers, error: 0.010598882713881336

[aMOF-delta]
23 points, 0 outliers, error: 0.014563493384749826

[lat-imp]
23 points, 0 outliers, error: 0.00228160166650453

[work-csv]
23 points, 0 outliers, error: 0.007252992610439838

[rlat-50-mean]
22 points, 1 outliers, error: 0.000003165294757708039

[rlat-99-mean]
22 points, 1 outliers, error: 0.00004883318499949513

[rlat-50-99]
21 points, 2 outliers, error: 0.00004118668882641492

[rlat-99-99]
21 points, 2 outliers, error: 0.00018015485774651135

[rlat-50-100]
22 points, 1 outliers, error: 0.00013802052188441994

[rlat-100-100]
22 points, 1 outliers, error: 0.04568097353998776

[wlat-50-mean]
21 points, 2 outliers, error: 0.000004729969520701066

[wlat-99-mean]
22 points, 1 outliers, error: 0.00011031272310534356

[wlat-50-99]
22 points, 1 outliers, error: 0.000008498092655295324

[wlat-99-99]
21 points, 2 outliers, error: 0.002581282782736685

[wlat-50-100]
22 points, 1 outliers, error: 0.000048060689421551766

[wlat-100-100]
22 points, 1 outliers, error: 0.04497661968502278
```

By the way, I thought about changing the `full` member of FormatOpts to be an enum with a 'mode' of Full, Summary, MergeSummary, but after looking at how invasive the patch was getting I backtracked. Let me know if you would prefer that.