### PR TITLE
Handle missing solutions on high level formatting

### DIFF
--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -2296,12 +2296,22 @@ impl IoCostTuneJob {
         // iocost-tune results full form format.
         let mut solutions = vec![];
         for rule in self.rules.iter() {
-            let sol = res.solutions.get(&rule.name).unwrap();
+            let sol = match res.solutions.get(&rule.name) {
+                Some(sol) => sol,
+                None => {
+                    println!("Solution {} not found...", rule.name);
+                    break;
+                }
+            };
             solutions.push(format!("{}={}%", &rule.name, format_pct(sol.scale_factor)));
         }
 
-        writeln!(out, "solutions : {}", &solutions[0..4].join(" ")).unwrap();
-        writeln!(out, "            {}", &solutions[4..].join(" ")).unwrap();
+        if solutions.len() < 4 {
+            writeln!(out, "solutions : {}", &solutions.join(" ")).unwrap();
+        } else {
+            writeln!(out, "solutions : {}", &solutions[0..4].join(" ")).unwrap();
+            writeln!(out, "            {}", &solutions[4..].join(" ")).unwrap();
+        }
     }
 
     fn format_rules<'a>(out: &mut Box<dyn Write + 'a>, rules: &[&QoSRule]) {


### PR DESCRIPTION
The high level formatting code relied on the rule names matching the
solutions, and on there being at least 4 solutions, which is not
always the case on files in the wild. Gracefully handle that.

Signed-off-by: Gustavo Noronha Silva <gustavo.noronha@collabora.com>