### PR TITLE
bench: Adding version information to result header 

### DIFF
--- a/resctl-bench/src/job.rs
+++ b/resctl-bench/src/job.rs
@@ -126,7 +126,13 @@ impl JobData {
     }
 
     pub fn format_header<'a>(&self, out: &mut Box<dyn Write + 'a>) {
-        write!(out, "[{} {} result] ", self.spec.kind, env!("CARGO_PKG_VERSION")).unwrap();
+        write!(
+            out,
+            "[{} {} result] ",
+            self.spec.kind,
+            env!("CARGO_PKG_VERSION")
+        )
+        .unwrap();
         if let Some(id) = self.spec.id.as_ref() {
             write!(out, "\"{}\" ", id).unwrap();
         }

--- a/resctl-bench/src/job.rs
+++ b/resctl-bench/src/job.rs
@@ -126,7 +126,7 @@ impl JobData {
     }
 
     pub fn format_header<'a>(&self, out: &mut Box<dyn Write + 'a>) {
-        write!(out, "[{} result] ", self.spec.kind).unwrap();
+        write!(out, "[{} {} result] ", self.spec.kind, env!("CARGO_PKG_VERSION")).unwrap();
         if let Some(id) = self.spec.id.as_ref() {
             write!(out, "\"{}\" ", id).unwrap();
         }


### PR DESCRIPTION
Simple change to mark the version of resctl-bench used to produce the result files.

Test
```
* ./build-and-tar.sh
* Sanity
./target/release/resctl-bench -r target/resctl-bench-result_2022_07_26-19_38_06.json format iocost-tune 
==========================================================================================

[iocost-tune 2.2.4 result] 2022-07-26 19:13:40 - 19:13:40
...
```