### PR TITLE
Hwdb adjustments

### DIFF
--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -2355,10 +2355,12 @@ impl IoCostTuneJob {
         .unwrap();
 
         for solution in available_solutions {
+            let normalized_name = solution.0.to_uppercase().replace("-", "_");
+
             writeln!(
                 out,
                 "\n  IOCOST_MODEL_{}=rbps={} rseqiops={} rrandiops={} wbps={} wseqiops={} wrandiops={}",
-                solution.0.to_uppercase(),
+                normalized_name,
                 solution.1.model.rbps,
                 solution.1.model.rseqiops,
                 solution.1.model.rrandiops,
@@ -2372,7 +2374,7 @@ impl IoCostTuneJob {
             write!(
                 out,
                 "  IOCOST_QOS_{}=rpct={:.2} rlat={} wpct={:.2} wlat={} min={:.2} max={:.2}",
-                solution.0.to_uppercase(),
+                normalized_name,
                 solution.1.qos.rpct,
                 solution.1.qos.rlat,
                 solution.1.qos.wpct,

--- a/resctl-bench/src/bench/iocost_tune.rs
+++ b/resctl-bench/src/bench/iocost_tune.rs
@@ -2333,7 +2333,7 @@ impl IoCostTuneJob {
         writeln!(out, "block:*:name:{}:", sysrep.scr_dev_model).unwrap();
 
         // Merge files may be missing some solutions, so try defaults in order.
-        let available_solutions: Vec<(&str, &QoSSolution)> = (*DEFAULT_HWDB_MODELS)
+        let mut available_solutions: Vec<(&str, &QoSSolution)> = (*DEFAULT_HWDB_MODELS)
             .iter()
             .map(|name| {
                 res.solutions
@@ -2353,6 +2353,16 @@ impl IoCostTuneJob {
                 .join(" ")
         )
         .unwrap();
+
+        // Now add the rlat solutions, they should not be present in the list of defaults
+        // but should be included in the file.
+        for (name, solution) in res.solutions.iter() {
+            if !name.starts_with("rlat") {
+                continue;
+            }
+
+            available_solutions.push((name, solution));
+        }
 
         for solution in available_solutions {
             let normalized_name = solution.0.to_uppercase().replace("-", "_");


### PR DESCRIPTION
This is basically to adapt the hwdb file that gets generated to requests made by the systemd maintainers. I am also including a commit to add the rlat solutions as we had agreed and I forgot for the initial merge. This is what the hwdb entry for a device looks like:

```
block:*:name:MZUL2256HCHQ-00AFB:
  IOCOST_SOLUTIONS=isolation isolated-bandwidth bandwidth naive
  IOCOST_MODEL_ISOLATION=rbps=626708081 rseqiops=27119 rrandiops=26638 wbps=138402498 wseqiops=3257 wrandiops=3208
  IOCOST_QOS_ISOLATION=rpct=0.00 rlat=1997 wpct=0.00 wlat=50837 min=100.00 max=100.00
  IOCOST_MODEL_ISOLATED_BANDWIDTH=rbps=997831946 rseqiops=43179 rrandiops=42412 wbps=220361662 wseqiops=5186 wrandiops=5107
  IOCOST_QOS_ISOLATED_BANDWIDTH=rpct=0.00 rlat=2213 wpct=0.00 wlat=61487 min=100.00 max=100.00
  IOCOST_MODEL_BANDWIDTH=rbps=1891663391 rseqiops=81857 rrandiops=80403 wbps=417755805 wseqiops=9832 wrandiops=9682
  IOCOST_QOS_BANDWIDTH=rpct=0.00 rlat=7034 wpct=0.00 wlat=87136 min=100.00 max=100.00
  IOCOST_MODEL_NAIVE=rbps=1891663391 rseqiops=81857 rrandiops=80403 wbps=417755805 wseqiops=9832 wrandiops=9682
  IOCOST_QOS_NAIVE=rpct=99.00 rlat=7034 wpct=99.00 wlat=87136 min=75.00 max=100.00
  IOCOST_MODEL_RLAT_99_Q1=rbps=1891663391 rseqiops=81857 rrandiops=80403 wbps=417755805 wseqiops=9832 wrandiops=9682
  IOCOST_QOS_RLAT_99_Q1=rpct=99.00 rlat=7034 wpct=0.00 wlat=0 min=87.66 max=100.00
  IOCOST_MODEL_RLAT_99_Q2=rbps=1658184837 rseqiops=71754 rrandiops=70479 wbps=366194295 wseqiops=8618 wrandiops=8487
  IOCOST_QOS_RLAT_99_Q2=rpct=99.00 rlat=5775 wpct=0.00 wlat=0 min=85.92 max=100.00
  IOCOST_MODEL_RLAT_99_Q3=rbps=1424706283 rseqiops=61651 rrandiops=60556 wbps=314632785 wseqiops=7405 wrandiops=7292
  IOCOST_QOS_RLAT_99_Q3=rpct=99.00 rlat=4515 wpct=0.00 wlat=0 min=83.61 max=100.00
  IOCOST_MODEL_RLAT_99_Q4=rbps=1191227729 rseqiops=51547 rrandiops=50632 wbps=263071274 wseqiops=6191 wrandiops=6097
  IOCOST_QOS_RLAT_99_Q4=rpct=99.00 rlat=3256 wpct=0.00 wlat=0 min=80.40 max=100.00
```