### PR TITLE
Check if  is set before parsing the field

### DIFF
--- a/resctl-bench/src/bench/iocost_qos.rs
+++ b/resctl-bench/src/bench/iocost_qos.rs
@@ -205,11 +205,13 @@ impl IoCostQoSJob {
             if dither {
                 if dither_dist.is_none() {
                     if let Some(pd) = prev_data.as_ref() {
-                        // If prev has dither_dist set, use the prev dither_dist
-                        // so that we can use results from it.
-                        let prec: IoCostQoSRecord = pd.parse_record()?;
-                        if let Some(pdd) = prec.dither_dist.as_ref() {
-                            dither_dist = Some(*pdd);
+                        if pd.record.is_some() {
+                            // If prev has dither_dist set, use the prev dither_dist
+                            // so that we can use results from it.
+                            let prec: IoCostQoSRecord = pd.parse_record()?;
+                            if let Some(pdd) = prec.dither_dist.as_ref() {
+                                dither_dist = Some(*pdd);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Currently, if we interrupt `resctl-bench` when it's creating the result file for the first time, it'd produce an incomplete result with null `record` field. Something like this:
```
[
  {
    "spec": {
      "kind": "iocost-params",
      "id": null,
      "passive": null,
      "props": [
        {}
      ]
    },
...
    "record": null,
    "result": null
  }
]
```
With such json file, if we try rerun `resctl-bench` it would crash since we're reusing `record` field unchecked. This pr fixes that.