### PR TITLE
Enable resctl-bench log dumping to file.

### DIFF
--- a/rd-agent-intf/src/args.rs
+++ b/rd-agent-intf/src/args.rs
@@ -25,7 +25,8 @@ lazy_static::lazy_static! {
              --reset            'Reset all states except for bench results, linux.tar and testfiles'
              --keep-reports     'Don't delete expired report files, also affects --reset'
              --bypass           'Skip startup and periodic health checks'
-         -v...                  'Sets the level of verbosity'",
+         -v...                  'Sets the level of verbosity'
+             --logfile=[FILE]   'Specify file to dump logs'",
         dfl_dir = Args::default().dir,
         dfl_rep_ret = Args::default().rep_retention as f64 / 3600.0,
         dfl_rep_1m_ret = Args::default().rep_1min_retention as f64 / 3600.0,
@@ -198,6 +199,8 @@ pub struct Args {
     pub bypass: bool,
     #[serde(skip)]
     pub verbosity: u32,
+    #[serde(skip)]
+    pub logfile: Option<String>,
 
     pub bandit: Option<Bandit>,
 }
@@ -222,6 +225,7 @@ impl Default for Args {
             keep_reports: false,
             bypass: false,
             verbosity: 0,
+            logfile: None,
             bandit: None,
         }
     }
@@ -300,6 +304,13 @@ impl JsonArgs for Args {
         matches.occurrences_of("v") as u32
     }
 
+    fn log_file(matches: &clap::ArgMatches) -> String {
+        match matches.value_of("logfile") {
+            Some(v) => v.to_string(),
+            None => "".to_string(),
+        }
+    }
+
     fn process_cmdline(&mut self, matches: &clap::ArgMatches) -> bool {
         let dfl = Args::default();
         let mut updated_base = false;
@@ -365,6 +376,7 @@ impl JsonArgs for Args {
         self.reset = matches.is_present("reset");
         self.keep_reports = matches.is_present("keep-reports");
         self.verbosity = Self::verbosity(&matches);
+        self.logfile = matches.value_of("logfile").map(|x| x.to_string());
         self.bypass = matches.is_present("bypass");
 
         match matches.value_of("passive") {

--- a/rd-hashd-intf/src/args.rs
+++ b/rd-hashd-intf/src/args.rs
@@ -41,7 +41,9 @@ lazy_static::lazy_static! {
                  --total-memory=[SIZE]     'Override total memory detection'
                  --total-swap=[SIZE]       'Override total swap space detection'
                  --nr-cpus=[NR]            'Override cpu count detection'
-             -v...                         'Sets the level of verbosity'",
+             -v...                         'Sets the level of verbosity'
+
+                 --logfile=[FILE]          'Specify file to dump trace logs'",
             dfl_size=to_gb(dfl_args.size),
             dfl_file_max_frac=dfl_args.file_max_frac,
             dfl_log_size=to_gb(dfl_args.log_size),
@@ -111,6 +113,8 @@ pub struct Args {
     bench_preload_cache: Option<usize>,
     #[serde(skip)]
     pub verbosity: u32,
+    #[serde(skip)]
+    pub logfile: Option<String>,
 }
 
 impl Args {
@@ -151,6 +155,7 @@ impl Args {
             bench_log_bps: dfl_params.log_bps,
             bench_file_frac: None,
             verbosity: 0,
+            logfile: None,
         }
     }
 
@@ -201,6 +206,13 @@ impl JsonArgs for Args {
 
     fn verbosity(matches: &ArgMatches) -> u32 {
         matches.occurrences_of("v") as u32
+    }
+
+    fn log_file(matches: &clap::ArgMatches) -> String {
+        match matches.value_of("logfile") {
+            Some(v) => v.to_string(),
+            None => "".to_string(),
+        }
     }
 
     fn system_configuration_overrides(
@@ -378,6 +390,7 @@ impl JsonArgs for Args {
         }
 
         self.verbosity = Self::verbosity(matches);
+        self.logfile = matches.value_of("logfile").map(|x| x.to_string());
 
         updated_base
     }

--- a/rd-util/src/json_file.rs
+++ b/rd-util/src/json_file.rs
@@ -210,6 +210,7 @@ where
 {
     fn match_cmdline() -> clap::ArgMatches<'static>;
     fn verbosity(matches: &clap::ArgMatches) -> u32;
+    fn log_file(matches: &clap::ArgMatches) -> String;
     fn system_configuration_overrides(
         _matches: &clap::ArgMatches,
     ) -> (Option<usize>, Option<usize>, Option<usize>) {
@@ -233,7 +234,7 @@ where
 {
     fn init_args_and_logging_nosave() -> Result<(JsonConfigFile<T>, bool)> {
         let matches = T::match_cmdline();
-        super::init_logging(T::verbosity(&matches));
+        super::init_logging(T::verbosity(&matches), T::log_file(&matches));
         let overrides = T::system_configuration_overrides(&matches);
         super::override_system_configuration(overrides.0, overrides.1, overrides.2);
 

--- a/resctl-bench-intf/src/args.rs
+++ b/resctl-bench-intf/src/args.rs
@@ -40,7 +40,8 @@ lazy_static::lazy_static! {
                  --force-shadow-inode-prot-test 'Force shadow inode protection test'
                  --skip-shadow-inode-prot-test 'Assume shadow inodes are protected without testing'
                  --test                   'Test mode for development'
-             -v...                        'Sets the level of verbosity'",
+             -v...                        'Sets the level of verbosity'
+                 --logfile=[FILE]         'Specify file to dump logs'",
             dfl_dir = dfl_args.dir,
             dfl_rep_ret = dfl_args.rep_retention,
             dfl_mem_prof = dfl_args.mem_profile.unwrap(),
@@ -161,6 +162,8 @@ pub struct Args {
     #[serde(skip)]
     pub verbosity: u32,
     #[serde(skip)]
+    pub logfile: Option<String>,
+    #[serde(skip)]
     pub rstat: u32,
     #[serde(skip)]
     pub merge_srcs: Vec<String>,
@@ -209,6 +212,7 @@ impl Default for Args {
             skip_shadow_inode_prot_test: false,
             test: false,
             verbosity: 0,
+            logfile: None,
             rstat: 0,
             merge_srcs: vec![],
             merge_by_id: false,
@@ -535,6 +539,13 @@ impl JsonArgs for Args {
         matches.occurrences_of("v") as u32
     }
 
+    fn log_file(matches: &clap::ArgMatches) -> String {
+        match matches.value_of("logfile") {
+            Some(v) => v.to_string(),
+            None => "".to_string(),
+        }
+    }
+
     fn process_cmdline(&mut self, matches: &clap::ArgMatches) -> bool {
         let dfl = Args::default();
         let mut updated = false;
@@ -654,6 +665,7 @@ impl JsonArgs for Args {
         self.skip_shadow_inode_prot_test = matches.is_present("skip-shadow-inode-prot-test");
         self.test = matches.is_present("test");
         self.verbosity = Self::verbosity(matches);
+        self.logfile = matches.value_of("logfile").map(|x| x.to_string());
 
         updated |= match matches.subcommand() {
             ("run", Some(subm)) => self.process_subcommand(Mode::Run, subm),

--- a/resctl-demo/src/main.rs
+++ b/resctl-demo/src/main.rs
@@ -522,7 +522,7 @@ fn main() {
     ARGS.lock().unwrap().replace(args);
 
     if std::env::var("RUST_LOG").is_ok() {
-        init_logging(0);
+        init_logging(0, "".to_string());
     } else {
         logger::init();
     }


### PR DESCRIPTION
~If environment variable LOG_DUMP_FILE=<filename>~
A new option --log-file is added to command line args. When filename is specified, the logs are also dumped to this file. Terminal output are logged as usual.

This logfile can be used for debugged purpose.