### PR TITLE
Integrate github app workflow with lambda.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2762,6 +2762,7 @@ dependencies = [
  "console",
  "env_logger",
  "indicatif",
+ "jsonwebtoken",
  "lambda_runtime",
  "lazy_static",
  "libc",

--- a/resctl-bench/Cargo.toml
+++ b/resctl-bench/Cargo.toml
@@ -24,6 +24,7 @@ aws-sdk-s3 = { version = "0.28.0", optional = true, features = ["rustls", "rt-to
 aws-sdk-ssm = { version = "0.28.0", optional = true, features = ["rustls", "rt-tokio"], default-features = false  }
 aws_lambda_events = "0.10.0"
 
+jsonwebtoken = "8.3.0"
 lambda_runtime = { version = "0.8.1", optional = true  }
 md5 = { version = "0.7", optional = true  }
 octocrab = { version = "0.28.0", optional = true, features = ["rustls"], default-features = false }

--- a/resctl-bench/doc/lambda.md
+++ b/resctl-bench/doc/lambda.md
@@ -87,6 +87,32 @@ We still need to configure our S3 bucket to allow public read only access, so th
 }
 ```
 
+
+We also store the credential parameters required to file a github issue in AWS Systems Manager -> parameter store.
+We use github app `iocost-issue-creater` to file a github issue, thus it's credentials information `App Id` and 
+`Private Key` are stored in parameter store.  
+```
+{
+    /iocost-bot/appid : "xxxx"
+    /iocost-bot/privatekey : "PEM format key"
+}
+```
+
+AWS lambda flow
+===============
+1. User generates the benchmark result on their device.  
+`$ resctl-bench -r "$RESULT_JSON" --logfile=$LOG_FILE run iocost-tun`
+2. User uploads the result to aws lambda function url as:  
+`resctl-bench -r <RESULT_JSON>   upload --upload-url  <AWS lambda function URL>`  
+e.g  
+`$resctl-bench --result resctl-bench-result_2022_07_01-00_26_40.json.gz upload --upload-url https://ygvr6jnjckwamfao5xztg6idiu0ukjeb.lambda-url.eu-west-1.on.aws`
+
+3. Lamda is tiggered automatically in AWS.
+     - It saves the benchmark result to S3 bucket.
+     - Then create a issue in iocost-benchmark/iocost-benchmarks project using `iocost-issue-creater` github app.
+     - Issue contain a link to benchmark result stored in s3 bucket.
+
+
 Deploying
 =========
 


### PR DESCRIPTION
A new github app "iocost-issue-creater" is created and installed in iocost-benchmark organization which has a permission to file issue on iocost-benachmarks repository.

When a user uploads the benchmark result with lambda url, lambda saves the benchmark result in aws s3 bucket and create a issue in iocost-benchmarks projects.