### PR TITLE
Move development version(main branch) from 2.2.4 to 2.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "rd-agent"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "rd-agent-intf"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2617,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "rd-hashd"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "rd-hashd-intf"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2655,7 +2655,7 @@ dependencies = [
 
 [[package]]
 name = "rd-util"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2750,7 +2750,7 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "resctl-bench"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -2795,7 +2795,7 @@ dependencies = [
 
 [[package]]
 name = "resctl-bench-intf"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2808,7 +2808,7 @@ dependencies = [
 
 [[package]]
 name = "resctl-demo"
-version = "2.2.4"
+version = "2.2.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/rd-agent-intf/Cargo.toml
+++ b/rd-agent-intf/Cargo.toml
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 [package]
 name = "rd-agent-intf"
-version = "2.2.4"
+version = "2.2.5"
 authors = ["Tejun Heo <tj@kernel.org>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -12,8 +12,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rd-util = { path = "../rd-util", version = "2.2.4" }
-rd-hashd-intf = { path = "../rd-hashd-intf", version = "2.2.4" }
+rd-util = { path = "../rd-util", version = "2.2.5" }
+rd-hashd-intf = { path = "../rd-hashd-intf", version = "2.2.5" }
 
 anyhow = "1.0"
 clap = "2.33"

--- a/rd-agent/Cargo.toml
+++ b/rd-agent/Cargo.toml
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 [package]
 name = "rd-agent"
-version = "2.2.4"
+version = "2.2.5"
 authors = ["Tejun Heo <tj@kernel.org>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -12,9 +12,9 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rd-util = { path = "../rd-util", version = "2.2.4" }
-rd-hashd-intf = { path = "../rd-hashd-intf", version = "2.2.4" }
-rd-agent-intf = { path = "../rd-agent-intf", version = "2.2.4" }
+rd-util = { path = "../rd-util", version = "2.2.5" }
+rd-hashd-intf = { path = "../rd-hashd-intf", version = "2.2.5" }
+rd-agent-intf = { path = "../rd-agent-intf", version = "2.2.5" }
 
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/rd-hashd-intf/Cargo.toml
+++ b/rd-hashd-intf/Cargo.toml
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 [package]
 name = "rd-hashd-intf"
-version = "2.2.4"
+version = "2.2.5"
 authors = ["Tejun Heo <tj@kernel.org>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rd-util = { path = "../rd-util", version = "2.2.4" }
+rd-util = { path = "../rd-util", version = "2.2.5" }
 
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/rd-hashd/Cargo.toml
+++ b/rd-hashd/Cargo.toml
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 [package]
 name = "rd-hashd"
-version = "2.2.4"
+version = "2.2.5"
 authors = ["Tejun Heo <tj@kernel.org>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -10,8 +10,8 @@ description = "Latency-sensitive pseudo workload for resctl-demo"
 readme = "README.md"
 
 [dependencies]
-rd-util = { path = "../rd-util", version = "2.2.4" }
-rd-hashd-intf = { path = "../rd-hashd-intf", version = "2.2.4" }
+rd-util = { path = "../rd-util", version = "2.2.5" }
+rd-hashd-intf = { path = "../rd-hashd-intf", version = "2.2.5" }
 
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/rd-util/Cargo.toml
+++ b/rd-util/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rd-util"
-version = "2.2.4"
+version = "2.2.5"
 authors = ["Tejun Heo <tj@kernel.org>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/resctl-bench-intf/Cargo.toml
+++ b/resctl-bench-intf/Cargo.toml
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 [package]
 name = "resctl-bench-intf"
-version = "2.2.4"
+version = "2.2.5"
 authors = ["Tejun Heo <tj@kernel.org>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,8 +14,8 @@ readme = "README.md"
 lambda = []
 
 [dependencies]
-rd-util = { path = "../rd-util", version = "2.2.4" }
-rd-agent-intf = { path = "../rd-agent-intf", version = "2.2.4" }
+rd-util = { path = "../rd-util", version = "2.2.5" }
+rd-agent-intf = { path = "../rd-agent-intf", version = "2.2.5" }
 
 anyhow = "1.0"
 clap = "2.33"

--- a/resctl-bench/Cargo.toml
+++ b/resctl-bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resctl-bench"
-version = "2.2.4"
+version = "2.2.5"
 authors = ["Tejun Heo <tj@kernel.org>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -13,10 +13,10 @@ description = "Whole system resource control benchmarks with realistic scenarios
 lambda = ["resctl-bench-intf/lambda", "aws-config", "aws-sdk-s3", "aws-sdk-ssm", "octocrab", "lambda_runtime", "md5", "tokio"]
 
 [dependencies]
-rd-util = { path = "../rd-util", version = "2.2.4" }
-rd-hashd-intf = { path = "../rd-hashd-intf", version = "2.2.4" }
-rd-agent-intf = { path = "../rd-agent-intf", version = "2.2.4" }
-resctl-bench-intf = { path = "../resctl-bench-intf", version = "2.2.4" }
+rd-util = { path = "../rd-util", version = "2.2.5" }
+rd-hashd-intf = { path = "../rd-hashd-intf", version = "2.2.5" }
+rd-agent-intf = { path = "../rd-agent-intf", version = "2.2.5" }
+resctl-bench-intf = { path = "../resctl-bench-intf", version = "2.2.5" }
 
 # For the lambda feature. We prefer rustls for all the crates we use to avoid incompatibilities.
 aws-config = { version = "0.55.3", optional = true, features = ["rustls", "rt-tokio"], default-features = false  }

--- a/resctl-demo/Cargo.toml
+++ b/resctl-demo/Cargo.toml
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates
 [package]
 name = "resctl-demo"
-version = "2.2.4"
+version = "2.2.5"
 authors = ["Tejun Heo <tj@kernel.org>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -12,9 +12,9 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rd-util = { path = "../rd-util", version = "2.2.4" }
-rd-hashd-intf = { path = "../rd-hashd-intf", version = "2.2.4" }
-rd-agent-intf = { path = "../rd-agent-intf", version = "2.2.4" }
+rd-util = { path = "../rd-util", version = "2.2.5" }
+rd-hashd-intf = { path = "../rd-hashd-intf", version = "2.2.5" }
+rd-agent-intf = { path = "../rd-agent-intf", version = "2.2.5" }
 
 anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
Now crates with version 2.2.4 is released in crates.io, so we need to update dev version to next version.