### PR TITLE
resctl-bench: Set default Lambda URL for benchmark upload

### DIFF
--- a/resctl-bench-intf/src/args.rs
+++ b/resctl-bench-intf/src/args.rs
@@ -491,7 +491,7 @@ impl JsonArgs for Args {
                         .takes_value(true)
                         .number_of_values(1)
                         .env("RESCTL_BENCH_UPLOAD_URL")
-                        .required(true)
+                        .default_value("https://yxvf2x7zfkqga6sknkxgczwonq0yvkrm.lambda-url.us-east-1.on.aws")
                         .help("The URL where the lambda function is accessible")
                     )
                     .arg(


### PR DESCRIPTION
The benchmark upload is supposed to be done to a central service. Include the default submission URL in a release such that users don't have to remember it.