### PR TITLE
rd-hashd: update pid from 3.0 to 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2191,9 +2191,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pid"
-version = "3.0.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d81764342f0ec3d969b9898925e5b0dc31c95466cb70a79a3064b33eb3b5480a"
+checksum = "d7c931ef9756cd5e3fa3d395bfe09df4dfa6f0612c6ca8f6b12927d17ca34e36"
 dependencies = [
  "num-traits",
 ]

--- a/rd-hashd/Cargo.toml
+++ b/rd-hashd/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2"
 linreg = "0.2"
 log = "0.4"
 num = "0.4"
-pid = "3.0"
+pid = "4.0"
 quantiles = "0.7"
 rand = { version = "0.8", features = ["small_rng"] }
 rand_distr = "0.4"

--- a/rd-hashd/src/bench.rs
+++ b/rd-hashd/src/bench.rs
@@ -741,16 +741,10 @@ impl Bench {
         params.file_size_mean = (params.file_size_mean as f64 * 1.05) as usize;
 
         let th = self.create_test_hasher(max_size, tf, &params, true);
-        let mut pid = Pid::new(
-            cfg.fsz_pid.kp,
-            cfg.fsz_pid.ki,
-            cfg.fsz_pid.kd,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-            1.0,
-        );
+        let mut pid = Pid::new(1.0, 1.0);
+        pid.p(cfg.fsz_pid.kp, 1.0);
+        pid.i(cfg.fsz_pid.ki,1.0);
+        pid.d(cfg.fsz_pid.kd, 1.0);
 
         // determine rps based on latency convergence
         while nr_rounds < cfg.rounds {

--- a/rd-hashd/src/hasher.rs
+++ b/rd-hashd/src/hasher.rs
@@ -444,8 +444,20 @@ impl DispatchThread {
         );
 
         (
-            Pid::new(lat.kp, lat.ki, lat.kd, 0.1, 0.1, 0.1, 1.0, 1.0),
-            Pid::new(rps.kp, rps.ki, rps.kd, 1.0, 1.0, 1.0, 1.0, 1.0),
+            {
+                let mut lat_pid = Pid::new(1.0, 1.0);
+                lat_pid.p(lat.kp, 0.1);
+                lat_pid.i(lat.ki,0.1);
+                lat_pid.d(lat.kd, 0.1);
+                lat_pid
+            },
+            {
+                let mut rps_pid = Pid::new(1.0, 1.0);
+                rps_pid.p(rps.kp, 1.0);
+                rps_pid.i(rps.ki,1.0);
+                rps_pid.d(rps.kd, 1.0);
+                rps_pid
+            }
         )
     }
 


### PR DESCRIPTION
Update pid dependency from 3.0 to 4.0.
Allows building with packaged version on Debian.
