### PR TITLE
resctl-demo: use native buffer from cursive

### DIFF
--- a/resctl-demo/Cargo.toml
+++ b/resctl-demo/Cargo.toml
@@ -20,9 +20,8 @@ anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 clap = "2.33"
 crossbeam = "0.8"
-cursive = { version = "0.20", default-features = false, features = ["termion"] }
-cursive_buffered_backend = "0.6"
-cursive-tabs = "0.7"
+cursive = { version = "0.21", default-features = false, features = ["termion-backend"] }
+cursive-tabs = "0.8"
 enum-iterator = "2.0"
 env_logger = "0.11"
 lazy_static = "1.4"

--- a/resctl-demo/src/doc.rs
+++ b/resctl-demo/src/doc.rs
@@ -622,7 +622,7 @@ pub fn show_doc(siv: &mut Cursive, target: &str, jump: bool, back: bool) {
 
 fn create_button<F>(prompt: &str, cb: F) -> impl View
 where
-    F: 'static + Fn(&mut Cursive),
+    F: 'static + Fn(&mut Cursive) + std::marker::Sync + std::marker::Send,
 {
     let trimmed = prompt.trim_start();
     let indent = &prompt[0..prompt.len() - trimmed.len()];

--- a/resctl-demo/src/main.rs
+++ b/resctl-demo/src/main.rs
@@ -81,7 +81,7 @@ lazy_static::lazy_static! {
     static ref LAYOUT: Mutex<Layout> = Mutex::new(Layout::new(Vec2::new(0, 0)));
     static ref ZOOMED_VIEW: Mutex<Vec<ZoomedView>> = Mutex::new(Vec::new());
     pub static ref STYLE_ALERT: Style = Style {
-        effects: Effect::Bold | Effect::Reverse,
+        effects: (Effect::Bold | Effect::Reverse).into(),
         color: (*COLOR_ALERT).into(),
     };
     pub static ref SVC_NAMES: Vec<String> = {
@@ -531,7 +531,7 @@ fn main() {
     info!("TEMP_DIR: {:?}", TEMP_DIR.path());
     touch_units();
 
-    let mut siv = Cursive::default();
+    let mut siv = cursive::default();
     set_cursive_theme(&mut siv);
 
     let _exit_guard = ExitGuard {};
@@ -612,14 +612,5 @@ fn main() {
     refresh_layout_and_kick(&mut siv);
     update_agent_zoomed_view(&mut siv);
 
-    // Run the event loop. Use the termion backend so that resctl-demo can
-    // be built without external dependencies. The buffered backend wrapping
-    // is necessary to avoid flickering, see
-    // https://github.com/gyscos/cursive/issues/525.
-    siv.run_with(|| {
-        let termion_backend = cursive::backends::termion::Backend::init().unwrap();
-        Box::new(cursive_buffered_backend::BufferedBackend::new(
-            termion_backend,
-        ))
-    })
+    siv.run()
 }


### PR DESCRIPTION
Removed `cursive_buffered_backend` dependency as `cursive` v0.21 includes its own buffered backend implementation.
Updated `cursive` and `cursive-tabs` to recent versions.