### PR TITLE
Use async zbus and block internally in rd-util

### DIFF
--- a/rd-util/Cargo.toml
+++ b/rd-util/Cargo.toml
@@ -34,8 +34,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 simplelog = "0.12"
 sysinfo = "0.30"
-zbus = "5.7.1"
-zbus_macros = { version = "5.7.1", features = ["blocking-api", "gvariant"] }
+tokio = {version = "1.45", features = ["rt", "rt-multi-thread"] }
+zbus = { version = "5.7.1", features = ["tokio"], default-features = false }
+zbus_macros = { version = "5.7.1", features = ["gvariant"] }
 
 [build-dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
Using the blocking versions of zbus, when vendoring it for a monorepo, affects other crates that might be trying to be leaner - and zbus documentations discourages using those functions anyway.

This diff just does the blocking internally inside rd-util so we don't have to use the blocking-api feature of zbus.